### PR TITLE
feat(health): expose memory store stats and uptime in /health endpoint

### DIFF
--- a/apps/gateway/server.js
+++ b/apps/gateway/server.js
@@ -164,12 +164,15 @@ app.get('/api/session-images/:sessionId/:fileName', async (req, res) => {
 
 app.get('/health', async (_, res) => {
   const sessionStats = await sessionStore.getStats();
+  const memoryStats = await longTermMemoryStore.getStats();
   res.json({
     ok: true,
+    uptime_seconds: Math.floor(process.uptime()),
     queue_size: queue.size(),
     llm: llmManager.getConfigSummary(),
     tools: toolConfigManager.getSummary(),
     session_store: sessionStats,
+    memory_store: memoryStats,
     workspace_store: {
       root_dir: workspaceManager.rootDir
     }

--- a/apps/runtime/session/longTermMemoryStore.js
+++ b/apps/runtime/session/longTermMemoryStore.js
@@ -190,6 +190,18 @@ class LongTermMemoryStore {
     }
     return items;
   }
+
+  async getStats() {
+    const store = await this.readStore();
+    const entries = Array.isArray(store.entries) ? store.entries : [];
+    const totalChars = entries.reduce((sum, e) => sum + String(e.content || '').length, 0);
+    return {
+      root_dir: this.rootDir,
+      entry_count: entries.length,
+      total_content_chars: totalChars,
+      updated_at: store.updated_at || null
+    };
+  }
 }
 
 let defaultStoreInstance = null;

--- a/test/runtime/longTermMemoryStore.test.js
+++ b/test/runtime/longTermMemoryStore.test.js
@@ -48,3 +48,21 @@ test('LongTermMemoryStore deduplicates by content', async () => {
   assert.ok(listed.items[0].keywords.includes('language'));
   assert.ok(listed.items[0].keywords.includes('zh'));
 });
+
+test('LongTermMemoryStore getStats returns entry count and total chars', async () => {
+  const store = createStore();
+
+  const stats0 = await store.getStats();
+  assert.equal(stats0.entry_count, 0);
+  assert.equal(stats0.total_content_chars, 0);
+  assert.ok(typeof stats0.root_dir === 'string');
+  assert.ok(stats0.updated_at !== undefined);
+
+  await store.addEntry({ content: 'hello world', keywords: ['hello'] });
+  await store.addEntry({ content: 'foo bar baz', keywords: ['foo'] });
+
+  const stats2 = await store.getStats();
+  assert.equal(stats2.entry_count, 2);
+  assert.equal(stats2.total_content_chars, 'hello world'.length + 'foo bar baz'.length);
+  assert.ok(stats2.updated_at);
+});


### PR DESCRIPTION
## Summary

Part of Phase E observability hardening (REQ-20260226-005).

The `/health` endpoint previously had no visibility into the long-term memory store state. This PR adds `LongTermMemoryStore.getStats()` and surfaces it in the health response alongside `uptime_seconds`.

## Changes

### `apps/runtime/session/longTermMemoryStore.js`
- Add `getStats()` method returning:
  - `entry_count`: total number of memory entries
  - `total_content_chars`: sum of all entry content lengths
  - `root_dir`: store directory path
  - `updated_at`: last write timestamp from the store file

### `apps/gateway/server.js`
- Call `longTermMemoryStore.getStats()` in `GET /health`
- Add `memory_store` field to health response
- Add `uptime_seconds` (`Math.floor(process.uptime())`) for quick liveness diagnostics

### `test/runtime/longTermMemoryStore.test.js`
- Add test: `getStats returns entry count and total chars`
  - Verifies zero-state on empty store
  - Verifies correct counts after adding two entries

## Test Results

```
npm test → 182/182 pass
```

## Health Response (after)

```json
{
  "ok": true,
  "uptime_seconds": 42,
  "queue_size": 0,
  "llm": { ... },
  "tools": { ... },
  "session_store": { "root_dir": "...", "session_count": 3 },
  "memory_store": {
    "root_dir": "data/long-term-memory",
    "entry_count": 7,
    "total_content_chars": 1240,
    "updated_at": "2026-02-26T04:00:00.000Z"
  },
  "workspace_store": { "root_dir": "..." }
}
```