### PR TITLE
feat(voice): add voice.synthesize tool and Web UI audio player

### DIFF
--- a/apps/gateway/public/chat.css
+++ b/apps/gateway/public/chat.css
@@ -622,3 +622,16 @@ body.chat-page {
     scroll-behavior: auto !important;
   }
 }
+
+/* Voice synthesis audio player */
+.message-audio {
+  margin-top: 8px;
+}
+
+.message-audio audio {
+  width: 100%;
+  max-width: 320px;
+  height: 36px;
+  border-radius: 18px;
+  outline: none;
+}

--- a/apps/runtime/tooling/adapters/voice.js
+++ b/apps/runtime/tooling/adapters/voice.js
@@ -1,0 +1,69 @@
+const { execFile } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const { ToolingError, ErrorCode } = require('../errors');
+
+const SCRIPT_PATH = path.resolve(__dirname, '../../../../scripts/qwen_voice_reply.py');
+const VALID_VOICE_TAGS = new Set(['jp', 'zh', 'en']);
+const DEFAULT_TIMEOUT_MS = 60000;
+
+/**
+ * voice.synthesize adapter
+ *
+ * Calls scripts/qwen_voice_reply.py to generate an ogg audio file via Qwen3-TTS.
+ * Returns a JSON result with the local audio path and metadata.
+ *
+ * Requires:
+ *   - python3 in PATH
+ *   - ffmpeg in PATH
+ *   - DASHSCOPE_API_KEY environment variable
+ */
+async function synthesize({ text, voice_tag = 'zh', model, voice, out } = {}) {
+  if (!text || typeof text !== 'string' || !text.trim()) {
+    throw new ToolingError(ErrorCode.INVALID_ARGS, 'text is required');
+  }
+  if (!VALID_VOICE_TAGS.has(voice_tag)) {
+    throw new ToolingError(ErrorCode.INVALID_ARGS, `voice_tag must be one of: ${[...VALID_VOICE_TAGS].join(', ')}`);
+  }
+  if (!process.env.DASHSCOPE_API_KEY) {
+    throw new ToolingError(ErrorCode.PERMISSION_DENIED, 'DASHSCOPE_API_KEY environment variable is not set');
+  }
+  if (!fs.existsSync(SCRIPT_PATH)) {
+    throw new ToolingError(ErrorCode.CONFIG_ERROR, `voice synthesis script not found: ${SCRIPT_PATH}`);
+  }
+
+  const args = [SCRIPT_PATH, text.trim(), '--voice-tag', voice_tag, '--emit-manifest'];
+  if (model) args.push('--model', model);
+  if (voice) args.push('--voice', voice);
+  if (out) args.push('--out', out);
+
+  return new Promise((resolve, reject) => {
+    execFile('python3', args, { timeout: DEFAULT_TIMEOUT_MS, env: process.env }, (err, stdout, stderr) => {
+      if (err) {
+        const detail = stderr ? stderr.trim().slice(0, 400) : String(err.message || err);
+        return reject(new ToolingError(ErrorCode.EXEC_ERROR, `voice synthesis failed: ${detail}`));
+      }
+
+      let manifest;
+      try {
+        manifest = JSON.parse(stdout.trim());
+      } catch {
+        return reject(new ToolingError(ErrorCode.EXEC_ERROR, `unexpected output from voice script: ${stdout.trim().slice(0, 200)}`));
+      }
+
+      if (!manifest.audio_path || !fs.existsSync(manifest.audio_path)) {
+        return reject(new ToolingError(ErrorCode.EXEC_ERROR, `audio file not found at: ${manifest.audio_path}`));
+      }
+
+      resolve(JSON.stringify({
+        ok: true,
+        audio_path: manifest.audio_path,
+        voice_tag: manifest.voice_tag,
+        model: manifest.model,
+        tts_input_text: manifest.tts_input_text,
+      }));
+    });
+  });
+}
+
+module.exports = { 'voice.synthesize': synthesize };

--- a/apps/runtime/tooling/toolRegistry.js
+++ b/apps/runtime/tooling/toolRegistry.js
@@ -2,13 +2,15 @@ const builtin = require('./adapters/builtin');
 const fsAdapters = require('./adapters/fs');
 const shellAdapters = require('./adapters/shell');
 const memoryAdapters = require('./adapters/memory');
+const voiceAdapters = require('./adapters/voice');
 const { ToolingError, ErrorCode } = require('./errors');
 
 const ADAPTERS = {
   ...builtin,
   ...fsAdapters,
   ...shellAdapters,
-  ...memoryAdapters
+  ...memoryAdapters,
+  ...voiceAdapters
 };
 
 class ToolRegistry {

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -10,6 +10,7 @@ policy:
     - workspace.write_file
     - shell.exec
     - persona.update_profile
+    - voice.synthesize
   deny: []
   byProvider: {}
 
@@ -118,4 +119,30 @@ tools:
       properties:
         custom_name: { type: string }
       required: [custom_name]
+      additionalProperties: false
+
+  - name: voice.synthesize
+    type: local
+    adapter: voice.synthesize
+    description: >
+      Synthesize text to speech using Qwen3-TTS and return a local ogg audio file path.
+      Requires DASHSCOPE_API_KEY, python3, and ffmpeg.
+      Use when the user asks for a voice reply or audio output.
+    input_schema:
+      type: object
+      properties:
+        text:
+          type: string
+          description: Text to synthesize (required)
+        voice_tag:
+          type: string
+          enum: [jp, zh, en]
+          description: "Language tag: jp=Japanese, zh=Chinese, en=English (default: zh)"
+        model:
+          type: string
+          description: TTS model override (optional)
+        voice:
+          type: string
+          description: Voice ID override (optional)
+      required: [text]
       additionalProperties: false

--- a/scripts/qwen_voice_reply.py
+++ b/scripts/qwen_voice_reply.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+qwen_voice_reply.py — Qwen3-TTS voice synthesis for open-yachiyo.
+
+Generates an ogg audio file from text using Alibaba Cloud DashScope TTS API.
+Outputs the local ogg file path to stdout (or JSON manifest with --emit-manifest).
+
+Requirements:
+  pip install dashscope
+  ffmpeg (in PATH)
+
+Environment:
+  DASHSCOPE_API_KEY  — DashScope API key (required)
+"""
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_MODEL = "qwen3-tts-vc-2026-01-22"
+DEFAULT_VOICE = "qwen-tts-vc-yachiyo-voice-20260224022238839-5679"
+MIN_AUDIO_BYTES = 1024
+
+VOICE_TAG_MAP = {
+    "jp": ("Japanese", "自然で親しみやすい日本語で話してください。"),
+    "zh": ("Chinese", "自然で聞き取りやすい中国語で話してください。"),
+    "en": ("English", "Speak in clear and natural English."),
+}
+
+
+def ensure_dashscope():
+    try:
+        import dashscope  # type: ignore
+        dashscope.base_http_api_url = "https://dashscope-intl.aliyuncs.com/api/v1"
+        return dashscope
+    except ImportError as e:
+        raise RuntimeError(
+            "dashscope not installed. Run: pip install dashscope"
+        ) from e
+
+
+def _extract_audio_url(resp) -> Optional[str]:
+    output = resp.output if hasattr(resp, "output") else {}
+    if isinstance(output, dict):
+        return (output.get("audio") or {}).get("url")
+    return output.audio.get("url") if getattr(output, "audio", None) else None
+
+
+def _download_with_retry(url: str, out_file: Path, retries: int = 3) -> None:
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    last_err: Optional[Exception] = None
+    for i in range(retries):
+        try:
+            urllib.request.urlretrieve(url, str(out_file))
+            if not out_file.exists() or out_file.stat().st_size < MIN_AUDIO_BYTES:
+                raise RuntimeError(
+                    f"Downloaded audio too small ({out_file.stat().st_size if out_file.exists() else 0} bytes)"
+                )
+            return
+        except Exception as e:
+            last_err = e
+            if i < retries - 1:
+                time.sleep(0.8 * (i + 1))
+    raise RuntimeError(f"Audio download failed after {retries} retries: {last_err}")
+
+
+def synthesize(text: str, model: str, voice: str, api_key: str, out_audio: Path, voice_tag: str) -> None:
+    dashscope = ensure_dashscope()
+    language_type, default_instruction = VOICE_TAG_MAP[voice_tag]
+
+    payload = {
+        "model": model,
+        "api_key": api_key,
+        "text": text,
+        "voice": voice,
+        "stream": False,
+        "language_type": language_type,
+    }
+    if "instruct" in model:
+        payload["instructions"] = default_instruction
+        payload["optimize_instructions"] = True
+
+    resp = dashscope.MultiModalConversation.call(**payload)
+    url = _extract_audio_url(resp)
+    if not url:
+        raise RuntimeError(f"Synthesis failed, no audio URL in response: {resp}")
+    _download_with_retry(url, out_audio)
+
+
+def to_ogg(in_audio: Path, out_ogg: Path) -> None:
+    out_ogg.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "ffmpeg", "-y", "-i", str(in_audio),
+        "-c:a", "libopus", "-b:a", "32k", "-vbr", "on", "-ac", "1", "-ar", "48000",
+        str(out_ogg),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffmpeg transcode failed: {proc.stderr.strip()}")
+    if not out_ogg.exists() or out_ogg.stat().st_size < MIN_AUDIO_BYTES:
+        raise RuntimeError(f"Transcoded audio too small ({out_ogg.stat().st_size if out_ogg.exists() else 0} bytes)")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Qwen3-TTS voice synthesis — outputs ogg file path")
+    p.add_argument("text", help="Text to synthesize")
+    p.add_argument("--voice-tag", choices=sorted(VOICE_TAG_MAP.keys()), required=True,
+                   help="Language tag: jp | zh | en")
+    p.add_argument("--voice", default=DEFAULT_VOICE)
+    p.add_argument("--model", default=DEFAULT_MODEL)
+    p.add_argument("--out", default="", help="Output ogg path (auto-generated if omitted)")
+    p.add_argument("--emit-manifest", action="store_true",
+                   help="Output JSON manifest instead of plain path")
+    args = p.parse_args()
+
+    api_key = os.getenv("DASHSCOPE_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("DASHSCOPE_API_KEY environment variable is required")
+
+    with tempfile.TemporaryDirectory(prefix="yachiyo-tts-") as td:
+        tmp_audio = Path(td) / "tts_raw.bin"
+        out_ogg = Path(args.out) if args.out else Path(tempfile.gettempdir()) / f"yachiyo-voice-{os.getpid()}-{int(time.time())}.ogg"
+
+        synthesize(args.text, args.model, args.voice, api_key, tmp_audio, args.voice_tag)
+        to_ogg(tmp_audio, out_ogg)
+
+    if args.emit_manifest:
+        print(json.dumps({
+            "audio_path": str(out_ogg),
+            "tts_input_text": args.text,
+            "voice_tag": args.voice_tag,
+            "model": args.model,
+            "voice": args.voice,
+        }, ensure_ascii=False))
+    else:
+        print(str(out_ogg))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/runtime/voiceSynthesis.test.js
+++ b/test/runtime/voiceSynthesis.test.js
@@ -1,0 +1,77 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+
+// Test the voice adapter module loads and exports the correct adapter key
+test('voice adapter exports voice.synthesize function', () => {
+  const voice = require('../../apps/runtime/tooling/adapters/voice');
+  assert.ok(typeof voice['voice.synthesize'] === 'function', 'voice.synthesize should be a function');
+});
+
+// Test validation: missing text
+test('voice.synthesize rejects missing text', async () => {
+  const voice = require('../../apps/runtime/tooling/adapters/voice');
+  await assert.rejects(
+    () => voice['voice.synthesize']({ voice_tag: 'zh' }),
+    (err) => {
+      assert.match(err.message, /text is required/i);
+      return true;
+    }
+  );
+});
+
+// Test validation: invalid voice_tag
+test('voice.synthesize rejects invalid voice_tag', async () => {
+  const voice = require('../../apps/runtime/tooling/adapters/voice');
+  await assert.rejects(
+    () => voice['voice.synthesize']({ text: 'hello', voice_tag: 'xx' }),
+    (err) => {
+      assert.match(err.message, /voice_tag must be one of/i);
+      return true;
+    }
+  );
+});
+
+// Test validation: missing DASHSCOPE_API_KEY
+test('voice.synthesize rejects when DASHSCOPE_API_KEY is not set', async () => {
+  const savedKey = process.env.DASHSCOPE_API_KEY;
+  delete process.env.DASHSCOPE_API_KEY;
+
+  const voice = require('../../apps/runtime/tooling/adapters/voice');
+  await assert.rejects(
+    () => voice['voice.synthesize']({ text: 'hello', voice_tag: 'zh' }),
+    (err) => {
+      assert.match(err.message, /DASHSCOPE_API_KEY/i);
+      return true;
+    }
+  );
+
+  if (savedKey !== undefined) process.env.DASHSCOPE_API_KEY = savedKey;
+});
+
+// Test toolRegistry loads voice adapter without error
+test('toolRegistry includes voice.synthesize adapter', () => {
+  const { ToolRegistry } = require('../../apps/runtime/tooling/toolRegistry');
+  const config = {
+    tools: [
+      {
+        name: 'voice.synthesize',
+        type: 'local',
+        adapter: 'voice.synthesize',
+        description: 'Synthesize voice',
+        input_schema: {
+          type: 'object',
+          properties: { text: { type: 'string' }, voice_tag: { type: 'string' } },
+          required: ['text'],
+          additionalProperties: false
+        }
+      }
+    ]
+  };
+  const registry = new ToolRegistry({ config });
+  const tool = registry.get('voice.synthesize');
+  assert.ok(tool, 'voice.synthesize should be registered');
+  assert.equal(tool.name, 'voice.synthesize');
+  assert.equal(typeof tool.run, 'function');
+});


### PR DESCRIPTION
## 功能说明

为 open-yachiyo 增加语音合成能力，LLM 可通过 `voice.synthesize` 工具将文本转为语音，Web UI 自动渲染内联音频播放器。

灵感来源：[yachiyo-qwen-voice-reply](https://github.com/wkf16/yachiyo-qwen-voice-reply)

## 变更内容

### `scripts/qwen_voice_reply.py`
- 基于 Qwen3-TTS（DashScope API）合成语音
- 通过 ffmpeg 转码为 ogg 格式
- 输出本地文件路径或 JSON manifest（`--emit-manifest`）
- 支持 `jp` / `zh` / `en` 三种语言标签

### `apps/runtime/tooling/adapters/voice.js`
- `voice.synthesize` 适配器，封装 Python 脚本调用
- 调用前校验 `text`、`voice_tag`、`DASHSCOPE_API_KEY`
- 返回 JSON 结果（audio_path + 元数据）

### `apps/runtime/tooling/toolRegistry.js`
- 注册 voiceAdapters

### `config/tools.yaml`
- 添加 `voice.synthesize` 工具定义和 policy 白名单

### `apps/gateway/server.js`
- 新增 `GET /api/audio?path=` 接口，用于向前端提供本地 ogg 文件
- 安全限制：只允许访问系统 tmp 目录下的 .ogg 文件

### `apps/gateway/public/chat.js`
- 新增 `extractAudioPath()`，检测消息内容是否为语音 manifest
- 检测到后自动渲染内联 `<audio>` 播放器

### `apps/gateway/public/chat.css`
- 音频播放器气泡样式

### `test/runtime/voiceSynthesis.test.js`
- 5 个单元测试（适配器导出、参数校验、API key 校验、registry 注册）

## 测试结果

```
npm test → 186/186 pass
```

本地语音合成验证通过（python3 + ffmpeg + DASHSCOPE_API_KEY）。

## 使用前提

```bash
pip install dashscope
export DASHSCOPE_API_KEY="your_key"
```

## 使用方式

启动服务后，在聊天框输入帮我用语音说：你好，LLM 会调用 `voice.synthesize` 工具，页面自动出现音频播放器。