### PR TITLE
Fix CI regressions after merge #54

### DIFF
--- a/test/desktop-live2d/bubbleTruncate.test.js
+++ b/test/desktop-live2d/bubbleTruncate.test.js
@@ -6,11 +6,11 @@ test('bubble truncate config has correct defaults', () => {
 
   const truncateConfig = DEFAULT_UI_CONFIG.chat.bubble.truncate;
 
-  assert.equal(truncateConfig.enabled, true, 'Truncate should be enabled by default');
-  assert.equal(truncateConfig.maxLength, 120, 'Default max length should be 120');
-  assert.equal(truncateConfig.mode, 'smart', 'Default mode should be smart');
+  assert.equal(truncateConfig.enabled, false, 'Truncate should be disabled by default');
+  assert.equal(truncateConfig.maxLength, 100000, 'Default max length should be 100000');
+  assert.equal(truncateConfig.mode, 'disabled', 'Default mode should be disabled');
   assert.equal(truncateConfig.suffix, '...', 'Default suffix should be ...');
-  assert.equal(truncateConfig.showHintForComplex, true, 'Should show hint for complex content');
+  assert.equal(truncateConfig.showHintForComplex, false, 'Should not show hint for complex content by default');
 });
 
 test('detect complex content - mermaid', () => {
@@ -159,4 +159,3 @@ test('truncate integration - complex content without hint', () => {
   assert.ok(result.includes('```'), 'Should truncate complex content when hint is disabled');
   assert.ok(result.length <= config.maxLength + config.suffix.length, 'Should respect maxLength');
 });
-

--- a/test/integration/gateway.e2e.test.js
+++ b/test/integration/gateway.e2e.test.js
@@ -171,6 +171,60 @@ async function startMockLlmServer(port) {
         };
       }
 
+      if (body?.stream) {
+        res.writeHead(200, {
+          'content-type': 'text/event-stream; charset=utf-8',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive'
+        });
+
+        const writeEvent = (payload) => {
+          res.write(`data: ${JSON.stringify(payload)}\n\n`);
+        };
+
+        if (Array.isArray(message?.tool_calls) && message.tool_calls.length > 0) {
+          for (let i = 0; i < message.tool_calls.length; i += 1) {
+            const tc = message.tool_calls[i];
+            writeEvent({
+              choices: [
+                {
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: i,
+                        id: tc.id,
+                        type: tc.type || 'function',
+                        function: {
+                          name: tc.function?.name,
+                          arguments: tc.function?.arguments || '{}'
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            });
+          }
+        }
+
+        const content = typeof message?.content === 'string' ? message.content : '';
+        if (content) {
+          writeEvent({
+            choices: [
+              {
+                delta: {
+                  content
+                }
+              }
+            ]
+          });
+        }
+
+        res.write('data: [DONE]\n\n');
+        res.end();
+        return;
+      }
+
       res.setHeader('content-type', 'application/json');
       res.end(JSON.stringify({ choices: [{ message }] }));
     });


### PR DESCRIPTION
## Why
Main CI failed after merge #54 due to two test/runtime expectation mismatches.

## Fixes
- Update truncate default expectations in `test/desktop-live2d/bubbleTruncate.test.js` to match current `DEFAULT_UI_CONFIG` (`enabled=false`, `maxLength=100000`, `mode=disabled`, `showHintForComplex=false`).
- Add SSE streaming response support in `test/integration/gateway.e2e.test.js` mock LLM server when `stream=true`, so runtime streaming path (`decideStream`) receives valid delta + `[DONE]`.

## Validation
- `npm run test:ci`
- Result: 375 passed, 0 failed
