### PR TITLE
feat(desktop-live2d): implement more natural lipsync

### DIFF
--- a/apps/desktop-live2d/main/config.js
+++ b/apps/desktop-live2d/main/config.js
@@ -83,6 +83,9 @@ function resolveDesktopLive2dConfig({ env = process.env, projectRoot = PROJECT_R
     importBackupRoot: path.resolve(
       env.DESKTOP_LIVE2D_BACKUP_ROOT || path.join(runtimePaths.dataDir, 'backups', 'live2d')
     ),
+    mouthWaveformDir: path.resolve(
+      env.DESKTOP_LIVE2D_MOUTH_WAVEFORM_DIR || path.join(runtimePaths.dataDir, 'desktop-live2d', 'mouth-waveforms')
+    ),
     rpcHost: '127.0.0.1',
     rpcPort,
     rpcToken,
@@ -214,6 +217,18 @@ function normalizeUiConfig(raw) {
         ...(raw?.interaction?.dragZone || {})
       }
     },
+    debug: {
+      ...DEFAULT_UI_CONFIG.debug,
+      ...(raw?.debug || {}),
+      mouthTuner: {
+        ...DEFAULT_UI_CONFIG.debug.mouthTuner,
+        ...(raw?.debug?.mouthTuner || {})
+      },
+      waveformCapture: {
+        ...DEFAULT_UI_CONFIG.debug.waveformCapture,
+        ...(raw?.debug?.waveformCapture || {})
+      }
+    },
     layout: {
       ...DEFAULT_UI_CONFIG.layout,
       ...(raw?.layout || {})
@@ -281,6 +296,11 @@ function normalizeUiConfig(raw) {
     merged.interaction.dragZone,
     DEFAULT_UI_CONFIG.interaction.dragZone
   );
+  merged.debug.mouthTuner.visible = Boolean(merged.debug.mouthTuner.visible);
+  merged.debug.mouthTuner.enabled = Boolean(merged.debug.mouthTuner.enabled);
+  merged.debug.waveformCapture.enabled = Boolean(merged.debug.waveformCapture.enabled);
+  merged.debug.waveformCapture.captureEveryFrame = merged.debug.waveformCapture.captureEveryFrame !== false;
+  merged.debug.waveformCapture.includeApplied = merged.debug.waveformCapture.includeApplied !== false;
 
   const layoutDefaults = DEFAULT_UI_CONFIG.layout;
   for (const key of Object.keys(layoutDefaults)) {
@@ -475,6 +495,64 @@ function upsertDesktopLive2dDragZoneOverrides(configPath, overrides = {}, { defa
   return nextRaw;
 }
 
+function cloneJsonValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneJsonValue(item));
+  }
+  if (isPlainObject(value)) {
+    const cloned = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      cloned[key] = cloneJsonValue(nestedValue);
+    }
+    return cloned;
+  }
+  return value;
+}
+
+function fillMissingWithDefaults(target, defaults, pathPrefix = '', addedPaths = []) {
+  if (!isPlainObject(defaults)) {
+    return {
+      value: target,
+      addedPaths
+    };
+  }
+
+  const nextValue = isPlainObject(target) ? { ...target } : {};
+
+  for (const [key, defaultValue] of Object.entries(defaults)) {
+    const nextPath = pathPrefix ? `${pathPrefix}.${key}` : key;
+    if (!Object.prototype.hasOwnProperty.call(nextValue, key) || nextValue[key] === undefined) {
+      nextValue[key] = cloneJsonValue(defaultValue);
+      addedPaths.push(nextPath);
+      continue;
+    }
+    if (isPlainObject(defaultValue) && isPlainObject(nextValue[key])) {
+      nextValue[key] = fillMissingWithDefaults(nextValue[key], defaultValue, nextPath, addedPaths).value;
+    }
+  }
+
+  return {
+    value: nextValue,
+    addedPaths
+  };
+}
+
+function syncDesktopLive2dMissingDefaults(configPath, { defaults = DEFAULT_UI_CONFIG } = {}) {
+  const currentRaw = fs.existsSync(configPath)
+    ? parseJsonWithComments(fs.readFileSync(configPath, 'utf8'))
+    : {};
+  const safeCurrent = isPlainObject(currentRaw) ? currentRaw : {};
+  const { value: nextRaw, addedPaths } = fillMissingWithDefaults(safeCurrent, defaults);
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, serializeDesktopLive2dUiConfig(nextRaw), 'utf8');
+
+  return {
+    nextRaw,
+    addedPaths
+  };
+}
+
 function serializeDesktopLive2dUiConfig(raw = {}) {
   const safe = isPlainObject(raw) ? raw : {};
   const orderedKeys = [];
@@ -534,6 +612,7 @@ module.exports = {
   parseJsonWithComments,
   upsertDesktopLive2dLayoutOverrides,
   upsertDesktopLive2dDragZoneOverrides,
+  syncDesktopLive2dMissingDefaults,
   serializeDesktopLive2dUiConfig,
   stripJsonComments,
   toPositiveInt,

--- a/apps/desktop-live2d/main/constants.js
+++ b/apps/desktop-live2d/main/constants.js
@@ -11,6 +11,7 @@ const DEFAULT_RENDERER_TIMEOUT_MS = 3000;
 
 const RPC_METHODS_V1 = Object.freeze([
   'state.get',
+  'debug.mouthOverride.set',
   'param.set',
   'model.param.set',
   'model.param.batchSet',

--- a/apps/desktop-live2d/main/desktopSuite.js
+++ b/apps/desktop-live2d/main/desktopSuite.js
@@ -876,6 +876,116 @@ function parseRendererDebugConsoleMessage(message) {
   }
 }
 
+function createMouthWaveformRecorder({
+  enabled = false,
+  outputDir = null,
+  logger = console,
+  idleCloseMs = 15000
+} = {}) {
+  const activeStreams = new Map();
+  const trackedTopics = new Set([
+    'chain.renderer.mouth.frame_sample',
+    'chain.renderer.lipsync.frame_applied'
+  ]);
+  let latestFilePath = null;
+
+  function sanitizeFileSegment(value) {
+    return String(value || 'unknown')
+      .trim()
+      .replace(/[^a-zA-Z0-9._-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 120) || 'unknown';
+  }
+
+  function closeEntry(requestId) {
+    const entry = activeStreams.get(requestId);
+    if (!entry) {
+      return;
+    }
+    activeStreams.delete(requestId);
+    try {
+      entry.stream.end();
+    } catch (err) {
+      logger.warn?.('[desktop-live2d] mouth waveform close failed', {
+        requestId,
+        error: err?.message || String(err || 'unknown error')
+      });
+    }
+  }
+
+  function ensureEntry(requestId) {
+    const normalizedRequestId = sanitizeFileSegment(requestId);
+    const existing = activeStreams.get(normalizedRequestId);
+    if (existing) {
+      existing.lastWriteAt = Date.now();
+      return existing;
+    }
+    if (!outputDir) {
+      return null;
+    }
+    fs.mkdirSync(outputDir, { recursive: true });
+    const filePath = path.join(outputDir, `${Date.now()}-${normalizedRequestId}.jsonl`);
+    const stream = fs.createWriteStream(filePath, { flags: 'a' });
+    const entry = {
+      stream,
+      filePath,
+      lastWriteAt: Date.now()
+    };
+    activeStreams.set(normalizedRequestId, entry);
+    latestFilePath = filePath;
+    return entry;
+  }
+
+  const pruneTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [requestId, entry] of activeStreams.entries()) {
+      if (!Number.isFinite(entry.lastWriteAt) || now - entry.lastWriteAt > idleCloseMs) {
+        closeEntry(requestId);
+      }
+    }
+  }, Math.max(1000, Math.min(idleCloseMs, 5000)));
+  pruneTimer.unref?.();
+
+  return {
+    record(topic, payload = {}) {
+      if (!enabled || !trackedTopics.has(topic)) {
+        return;
+      }
+      const requestId = payload?.request_id || 'unknown';
+      const entry = ensureEntry(requestId);
+      if (!entry) {
+        return;
+      }
+      entry.lastWriteAt = Date.now();
+      try {
+        entry.stream.write(`${JSON.stringify({
+          topic,
+          recorded_at: Date.now(),
+          ...payload
+        })}\n`);
+      } catch (err) {
+        logger.warn?.('[desktop-live2d] mouth waveform write failed', {
+          requestId,
+          error: err?.message || String(err || 'unknown error')
+        });
+      }
+    },
+    getState() {
+      return {
+        enabled: Boolean(enabled),
+        outputDir,
+        latestFilePath
+      };
+    },
+    dispose() {
+      clearInterval(pruneTimer);
+      for (const requestId of Array.from(activeStreams.keys())) {
+        closeEntry(requestId);
+      }
+    }
+  };
+}
+
 function summarizeProviderErrorMeta(meta) {
   if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
     return {};
@@ -2790,6 +2900,7 @@ async function startDesktopSuite({
     if (!parsed) {
       return;
     }
+    mouthWaveformRecorder.record(`chain.renderer.${parsed.event}`, parsed.data || {});
     emitDesktopDebug(`chain.renderer.${parsed.event}`, 'renderer emitted debug marker', {
       level: Number.isFinite(Number(level)) ? Number(level) : null,
       source_line: Number.isFinite(Number(line)) ? Number(line) : null,
@@ -2797,6 +2908,11 @@ async function startDesktopSuite({
       ...(parsed.data || {})
     });
   };
+  const mouthWaveformRecorder = createMouthWaveformRecorder({
+    enabled: config.uiConfig?.debug?.waveformCapture?.enabled === true,
+    outputDir: config.mouthWaveformDir,
+    logger
+  });
   avatarWindow.webContents.on('console-message', rendererConsoleListener);
 
   const gatewayRuntimeClient = new GatewayRuntimeClient({
@@ -3173,6 +3289,7 @@ async function startDesktopSuite({
     ipcMain.off(CHANNELS.windowInteractivity, avatarWindowInteractivityListener);
     ipcMain.off(CHANNELS.chatInputSubmit, chatInputListener);
     avatarWindow.webContents.off('console-message', rendererConsoleListener);
+    mouthWaveformRecorder.dispose();
 
     if (rpcServerRef) {
       await rpcServerRef.stop();

--- a/apps/desktop-live2d/main/rpcValidator.js
+++ b/apps/desktop-live2d/main/rpcValidator.js
@@ -17,6 +17,16 @@ const METHOD_SCHEMAS = Object.freeze({
     type: 'object',
     additionalProperties: false
   },
+  'debug.mouthOverride.set': {
+    type: 'object',
+    required: ['enabled'],
+    additionalProperties: false,
+    properties: {
+      enabled: { type: 'boolean' },
+      mouthOpen: { type: 'number' },
+      mouthForm: { type: 'number' }
+    }
+  },
   'param.set': PARAM_SET_SCHEMA,
   'model.param.set': PARAM_SET_SCHEMA,
   'model.param.batchSet': {

--- a/apps/desktop-live2d/renderer/bootstrap.js
+++ b/apps/desktop-live2d/renderer/bootstrap.js
@@ -46,14 +46,47 @@
   let lipsyncTargetMouthForm = 0;
   let lipsyncCurrentMouthOpen = 0;
   let lipsyncCurrentMouthForm = 0;
+  let lipsyncBaselineMouthOpen = 0;
+  let lipsyncBaselineMouthForm = 0;
   let lipsyncSpeakingActive = false;
   let lipsyncDetachModelHook = null;
   let lipsyncDetachTickerHook = null;
+  let mouthOverrideDetachModelHook = null;
+  let mouthOverrideDetachTickerHook = null;
   let lipsyncApplyMode = 'raf_direct';
   let activeVoiceRequestId = null;
   let systemAudioDebugBound = false;
   let realtimeVoicePlayer = null;
+  let faceBlendState = {
+    current: {
+      mouthForm: 0,
+      eyeSmileL: 0,
+      eyeSmileR: 0,
+      cheek: 0
+    },
+    target: {
+      mouthForm: 0,
+      eyeSmileL: 0,
+      eyeSmileR: 0,
+      cheek: 0
+    }
+  };
   let layoutTunerState = null;
+  let mouthTunerState = {
+    open: false,
+    enabled: false,
+    values: {
+      mouthOpen: 0,
+      mouthForm: 0
+    }
+  };
+  let externalMouthOverrideState = {
+    enabled: false,
+    values: {
+      mouthOpen: 0,
+      mouthForm: 0
+    }
+  };
   let lastWindowInteractivity = null;
   let lastPointerPosition = null;
 
@@ -67,6 +100,17 @@
   const chatComposerElement = document.getElementById('chat-panel-composer');
   const petHideElement = document.getElementById('pet-hide');
   const petCloseElement = document.getElementById('pet-close');
+  const mouthTunerToggleElement = document.getElementById('mouth-tuner-toggle');
+  const mouthTunerPanelElement = document.getElementById('mouth-tuner-panel');
+  const mouthTunerCloseElement = document.getElementById('mouth-tuner-close');
+  const mouthTunerEnableElement = document.getElementById('mouth-tuner-enable');
+  const mouthOpenElement = document.getElementById('mouth-open');
+  const mouthFormElement = document.getElementById('mouth-form');
+  const mouthOpenValueElement = document.getElementById('mouth-open-value');
+  const mouthFormValueElement = document.getElementById('mouth-form-value');
+  const mouthNeutralElement = document.getElementById('mouth-neutral');
+  const mouthApplyIElement = document.getElementById('mouth-apply-i');
+  const mouthTunerStatusElement = document.getElementById('mouth-tuner-status');
   const resizeModeCloseElement = document.getElementById('resize-mode-close');
   const layoutTunerToggleElement = document.getElementById('layout-tuner-toggle');
   const dragZoneToggleElement = document.getElementById('drag-zone-toggle');
@@ -135,13 +179,28 @@
   const CHAT_PANEL_SHOW_WAIT_RESIZE_TIMEOUT_MS = 220;
   const MODEL_TAP_SUPPRESS_AFTER_DRAG_MS = 220;
   const MODEL_TAP_SUPPRESS_AFTER_FOCUS_MS = 240;
-  const LIPSYNC_OPEN_GAIN_MIN = 1.35;
-  const LIPSYNC_OPEN_GAIN_MAX = 1.95;
-  const LIPSYNC_FORM_GAIN_MIN = 1.2;
-  const LIPSYNC_FORM_GAIN_MAX = 1.7;
-  const LIPSYNC_OPEN_GAMMA = 0.78;
   const LIPSYNC_ACTIVE_ENERGY_MIN = 0.018;
-  const LIPSYNC_MIN_OPEN_WHEN_SPEAKING = 0.12;
+  const LIPSYNC_BASELINE_OPEN_ALPHA = 0.024;
+  const LIPSYNC_BASELINE_FORM_ALPHA = 0.02;
+  const LIPSYNC_VARIANCE_OPEN_GAIN_MIN = 3.0;
+  const LIPSYNC_VARIANCE_OPEN_GAIN_MAX = 4.0;
+  const LIPSYNC_VARIANCE_OPEN_NEGATIVE_GAIN = 0.82;
+  const LIPSYNC_SPEAKING_OPEN_FLOOR_RATIO = 0.36;
+  const LIPSYNC_VARIANCE_FORM_GAIN_MIN = 2.0;
+  const LIPSYNC_VARIANCE_FORM_GAIN_MAX = 3.0;
+  const FACE_BLEND_ATTACK = 0.2;
+  const FACE_BLEND_RELEASE = 0.12;
+  const FACE_BLEND_SPEECH_MOUTHFORM_WEIGHT = 0.18;
+  const DEFAULT_MOUTH_BASE_POSE = Object.freeze({
+    mouthOpen: 0,
+    mouthForm: 0
+  });
+  const FACE_BLEND_DEFAULTS = Object.freeze({
+    mouthForm: 0,
+    eyeSmileL: 0,
+    eyeSmileR: 0,
+    cheek: 0
+  });
 
   function nearlyEqual(left, right, epsilon = 1e-4) {
     if (typeof interactionApi?.nearlyEqual === 'function') {
@@ -217,6 +276,458 @@
   function roundToStep(value, step = 1) {
     const safeStep = Number(step) || 1;
     return Math.round((Number(value) || 0) / safeStep) * safeStep;
+  }
+
+  function normalizeMouthTunerValues(input = {}) {
+    return {
+      mouthOpen: Math.round(clamp(Number(input.mouthOpen) || 0, 0, 1) * 100) / 100,
+      mouthForm: Math.round(clamp(Number(input.mouthForm) || 0, -1, 1) * 100) / 100
+    };
+  }
+
+  function getDefaultMouthBasePose() {
+    return normalizeMouthTunerValues(DEFAULT_MOUTH_BASE_POSE);
+  }
+
+  function syncLipsyncStateToDefaultMouthBasePose() {
+    const basePose = getDefaultMouthBasePose();
+    lipsyncTargetMouthOpen = basePose.mouthOpen;
+    lipsyncTargetMouthForm = basePose.mouthForm;
+    lipsyncCurrentMouthOpen = basePose.mouthOpen;
+    lipsyncCurrentMouthForm = basePose.mouthForm;
+    lipsyncBaselineMouthOpen = basePose.mouthOpen;
+    lipsyncBaselineMouthForm = basePose.mouthForm;
+    return basePose;
+  }
+
+  function normalizeFaceBlendValues(input = {}) {
+    return {
+      mouthForm: Math.round(clamp(Number(input.mouthForm) || 0, -1, 1) * 100) / 100,
+      eyeSmileL: Math.round(clamp(Number(input.eyeSmileL) || 0, 0, 1) * 100) / 100,
+      eyeSmileR: Math.round(clamp(Number(input.eyeSmileR) || 0, 0, 1) * 100) / 100,
+      cheek: Math.round(clamp(Number(input.cheek) || 0, 0, 1) * 100) / 100
+    };
+  }
+
+  function createFaceBlendValues(input = {}) {
+    return normalizeFaceBlendValues({
+      ...FACE_BLEND_DEFAULTS,
+      ...(input && typeof input === 'object' ? input : {})
+    });
+  }
+
+  function isMixableFaceParam(name) {
+    return [
+      'ParamMouthForm',
+      'ParamEyeLSmile',
+      'ParamEyeRSmile',
+      'ParamCheek'
+    ].includes(String(name || ''));
+  }
+
+  function mapExpressionNameToFaceBlendTarget(name) {
+    switch (String(name || '').trim()) {
+      case 'smile':
+        return createFaceBlendValues({
+          mouthForm: 0.28,
+          eyeSmileL: 0.92,
+          eyeSmileR: 0.92,
+          cheek: 0.2
+        });
+      case 'narrow_eyes':
+        return createFaceBlendValues({
+          mouthForm: 0.04,
+          eyeSmileL: 0.12,
+          eyeSmileR: 0.12,
+          cheek: 0.08
+        });
+      case 'tear_drop':
+        return createFaceBlendValues({
+          mouthForm: -0.04,
+          eyeSmileL: 0,
+          eyeSmileR: 0,
+          cheek: 0
+        });
+      case 'tears':
+        return createFaceBlendValues({
+          mouthForm: -0.08,
+          eyeSmileL: 0,
+          eyeSmileR: 0,
+          cheek: 0
+        });
+      default:
+        return createFaceBlendValues();
+    }
+  }
+
+  function setFaceBlendTarget(nextValues = {}, { replace = false } = {}) {
+    const target = replace
+      ? { ...FACE_BLEND_DEFAULTS, ...(nextValues || {}) }
+      : { ...faceBlendState.target, ...(nextValues || {}) };
+    faceBlendState.target = createFaceBlendValues(target);
+    return faceBlendState.target;
+  }
+
+  function resetFaceBlendTarget() {
+    faceBlendState.target = createFaceBlendValues();
+    return faceBlendState.target;
+  }
+
+  function isVoiceFaceContextActive() {
+    return Boolean(activeVoiceRequestId || lipsyncAnimationFrame || lipsyncReleaseAnimationFrame || lipsyncSpeakingActive);
+  }
+
+  function stepFaceBlendState() {
+    const next = {};
+    for (const key of Object.keys(FACE_BLEND_DEFAULTS)) {
+      const current = Number(faceBlendState.current?.[key]) || 0;
+      const target = Number(faceBlendState.target?.[key]) || 0;
+      const alpha = Math.abs(target) > Math.abs(current) ? FACE_BLEND_ATTACK : FACE_BLEND_RELEASE;
+      next[key] = lerp(current, target, alpha);
+    }
+    faceBlendState.current = createFaceBlendValues(next);
+    return faceBlendState.current;
+  }
+
+  function applyCompositeFacePoseToModel({ mouthOpen = null, mouthForm = null, speaking = false } = {}) {
+    if (!live2dModel || !state.modelLoaded) {
+      return { ok: false, skipped: true, reason: 'model_not_loaded' };
+    }
+    const coreModel = live2dModel?.internalModel?.coreModel;
+    if (!coreModel || typeof coreModel.setParameterValueById !== 'function') {
+      return { ok: false, skipped: true, reason: 'core_model_unavailable' };
+    }
+    const basePose = getDefaultMouthBasePose();
+    const faceBlend = stepFaceBlendState();
+    const voiceFaceContext = isVoiceFaceContextActive() || Boolean(speaking);
+    const emotionMouthWeight = voiceFaceContext ? FACE_BLEND_SPEECH_MOUTHFORM_WEIGHT : 1;
+    const resolvedMouthOpen = clamp(Number.isFinite(Number(mouthOpen)) ? Number(mouthOpen) : basePose.mouthOpen, 0, 1);
+    const resolvedMouthForm = clamp(Number.isFinite(Number(mouthForm)) ? Number(mouthForm) : basePose.mouthForm, -1, 1);
+    const finalMouthForm = clamp(
+      resolvedMouthForm + faceBlend.mouthForm * emotionMouthWeight,
+      -1,
+      1
+    );
+
+    try {
+      coreModel.setParameterValueById('ParamMouthOpenY', resolvedMouthOpen);
+      coreModel.setParameterValueById('ParamMouthForm', finalMouthForm);
+      coreModel.setParameterValueById('ParamEyeLSmile', faceBlend.eyeSmileL);
+      coreModel.setParameterValueById('ParamEyeRSmile', faceBlend.eyeSmileR);
+      coreModel.setParameterValueById('ParamCheek', faceBlend.cheek);
+      return {
+        ok: true,
+        values: {
+          mouthOpen: resolvedMouthOpen,
+          mouthForm: finalMouthForm,
+          faceBlend
+        }
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err?.message || String(err || 'unknown error')
+      };
+    }
+  }
+
+  function setMouthTunerStatus(message = '') {
+    if (mouthTunerStatusElement) {
+      mouthTunerStatusElement.textContent = String(message || '');
+    }
+  }
+
+  function getMouthTunerRuntimeConfig() {
+    const raw = runtimeUiConfig?.debug?.mouthTuner;
+    const config = raw && typeof raw === 'object' ? raw : {};
+    return {
+      visible: config.visible === true,
+      enabled: config.enabled === true
+    };
+  }
+
+  function getWaveformCaptureRuntimeConfig() {
+    const raw = runtimeUiConfig?.debug?.waveformCapture;
+    const config = raw && typeof raw === 'object' ? raw : {};
+    return {
+      enabled: config.enabled === true,
+      captureEveryFrame: config.captureEveryFrame !== false,
+      includeApplied: config.includeApplied !== false
+    };
+  }
+
+  function setMouthTunerVisible(visible) {
+    const nextVisible = Boolean(visible);
+    document.body.classList.toggle('mouth-tuner-visible', nextVisible);
+    if (mouthTunerToggleElement) {
+      mouthTunerToggleElement.hidden = !nextVisible;
+    }
+    if (mouthTunerPanelElement) {
+      mouthTunerPanelElement.hidden = !nextVisible;
+    }
+    if (!nextVisible) {
+      mouthTunerState.open = false;
+      document.body.classList.remove('mouth-tuner-open');
+    }
+  }
+
+  function syncMouthTunerControls() {
+    const values = mouthTunerState?.values || normalizeMouthTunerValues();
+    if (mouthTunerEnableElement) {
+      mouthTunerEnableElement.checked = Boolean(mouthTunerState?.enabled);
+    }
+    if (mouthOpenElement) mouthOpenElement.value = values.mouthOpen.toFixed(2);
+    if (mouthFormElement) mouthFormElement.value = values.mouthForm.toFixed(2);
+    if (mouthOpenValueElement) mouthOpenValueElement.textContent = values.mouthOpen.toFixed(2);
+    if (mouthFormValueElement) mouthFormValueElement.textContent = values.mouthForm.toFixed(2);
+  }
+
+  function setMouthTunerOpen(open) {
+    if (!document.body.classList.contains('mouth-tuner-visible')) {
+      mouthTunerState.open = false;
+      document.body.classList.remove('mouth-tuner-open');
+      return;
+    }
+    mouthTunerState.open = Boolean(open);
+    document.body.classList.toggle('mouth-tuner-open', mouthTunerState.open);
+  }
+
+  function applyRawMouthPoseToModel(values = {}, { force = false } = {}) {
+    if (!live2dModel || !state.modelLoaded) {
+      return { ok: false, skipped: true, reason: 'model_not_loaded' };
+    }
+    const coreModel = live2dModel?.internalModel?.coreModel;
+    if (!coreModel) {
+      return { ok: false, skipped: true, reason: 'core_model_unavailable' };
+    }
+    const normalized = normalizeMouthTunerValues(values);
+    try {
+      if (force || typeof coreModel.addParameterValueById !== 'function') {
+        coreModel.setParameterValueById('ParamMouthOpenY', normalized.mouthOpen);
+        coreModel.setParameterValueById('ParamMouthForm', normalized.mouthForm);
+      } else {
+        coreModel.addParameterValueById('ParamMouthOpenY', normalized.mouthOpen, 1);
+        coreModel.addParameterValueById('ParamMouthForm', normalized.mouthForm, 1);
+      }
+      return {
+        ok: true,
+        values: normalized
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err?.message || String(err || 'unknown error'),
+        values: normalized
+      };
+    }
+  }
+
+  function getActiveMouthOverrideValues() {
+    if (externalMouthOverrideState?.enabled) {
+      return externalMouthOverrideState.values || normalizeMouthTunerValues();
+    }
+    if (mouthTunerState?.enabled) {
+      return mouthTunerState.values || normalizeMouthTunerValues();
+    }
+    return null;
+  }
+
+  function applyActiveMouthOverrideForCurrentFrame() {
+    const overrideValues = getActiveMouthOverrideValues();
+    if (!overrideValues) {
+      return false;
+    }
+    lipsyncCurrentMouthOpen = overrideValues.mouthOpen;
+    lipsyncCurrentMouthForm = overrideValues.mouthForm;
+    return applyCompositeFacePoseToModel({
+      mouthOpen: overrideValues.mouthOpen,
+      mouthForm: overrideValues.mouthForm,
+      speaking: lipsyncSpeakingActive
+    }).ok === true;
+  }
+
+  function shouldApplyDefaultMouthBasePose() {
+    if (getActiveMouthOverrideValues()) {
+      return false;
+    }
+    if (lipsyncReleaseAnimationFrame || lipsyncSpeakingActive) {
+      return false;
+    }
+    if (lipsyncAnimationFrame) {
+      return false;
+    }
+    return true;
+  }
+
+  function applyDefaultMouthBasePoseForCurrentFrame() {
+    const basePose = syncLipsyncStateToDefaultMouthBasePose();
+    return applyCompositeFacePoseToModel({
+      mouthOpen: basePose.mouthOpen,
+      mouthForm: basePose.mouthForm,
+      speaking: false
+    }).ok === true;
+  }
+
+  function bindPersistentMouthOverrideHook() {
+    if (typeof mouthOverrideDetachModelHook === 'function' || typeof mouthOverrideDetachTickerHook === 'function') {
+      return true;
+    }
+    const internalModel = live2dModel?.internalModel;
+    if (internalModel && typeof internalModel.on === 'function') {
+      const handler = () => {
+        if (applyActiveMouthOverrideForCurrentFrame()) {
+          return;
+        }
+        if (shouldApplyDefaultMouthBasePose()) {
+          applyDefaultMouthBasePoseForCurrentFrame();
+        }
+      };
+      internalModel.on('beforeModelUpdate', handler);
+      mouthOverrideDetachModelHook = () => {
+        if (typeof internalModel.off === 'function') {
+          internalModel.off('beforeModelUpdate', handler);
+        } else if (typeof internalModel.removeListener === 'function') {
+          internalModel.removeListener('beforeModelUpdate', handler);
+        }
+      };
+      return true;
+    }
+    if (pixiApp?.ticker && typeof pixiApp.ticker.add === 'function') {
+      const tick = () => {
+        if (applyActiveMouthOverrideForCurrentFrame()) {
+          return;
+        }
+        if (shouldApplyDefaultMouthBasePose()) {
+          applyDefaultMouthBasePoseForCurrentFrame();
+        }
+      };
+      pixiApp.ticker.add(tick);
+      mouthOverrideDetachTickerHook = () => {
+        if (pixiApp?.ticker && typeof pixiApp.ticker.remove === 'function') {
+          pixiApp.ticker.remove(tick);
+        }
+      };
+      return true;
+    }
+    return false;
+  }
+
+  function applyMouthTunerValues(nextValues = {}, { immediate = false, statusMessage = '' } = {}) {
+    mouthTunerState.values = normalizeMouthTunerValues({
+      ...(mouthTunerState?.values || {}),
+      ...nextValues
+    });
+    syncMouthTunerControls();
+    if (statusMessage) {
+      setMouthTunerStatus(statusMessage);
+    }
+    if (immediate && mouthTunerState.enabled) {
+      applyRawMouthPoseToModel(mouthTunerState.values, { force: true });
+    }
+  }
+
+  function setMouthTunerEnabled(enabled, { immediate = false, statusMessage = '' } = {}) {
+    mouthTunerState.enabled = Boolean(enabled);
+    syncMouthTunerControls();
+    if (mouthTunerState.enabled) {
+      setMouthTunerStatus(statusMessage || 'Override active');
+      if (immediate) {
+        applyRawMouthPoseToModel(mouthTunerState.values, { force: true });
+      }
+      return;
+    }
+    setMouthTunerStatus(statusMessage || 'Override disabled');
+  }
+
+  function setExternalMouthOverride(params = {}) {
+    const enabled = params?.enabled === true;
+    externalMouthOverrideState = {
+      enabled,
+      values: normalizeMouthTunerValues({
+        ...(externalMouthOverrideState?.values || {}),
+        ...params
+      })
+    };
+    if (enabled) {
+      applyRawMouthPoseToModel(externalMouthOverrideState.values, { force: true });
+    }
+    return {
+      ok: true,
+      enabled,
+      values: externalMouthOverrideState.values
+    };
+  }
+
+  function initMouthTuner() {
+    const mouthTunerConfig = getMouthTunerRuntimeConfig();
+    mouthTunerState = {
+      open: false,
+      enabled: mouthTunerConfig.enabled,
+      values: normalizeMouthTunerValues({
+        mouthOpen: 0,
+        mouthForm: 0
+      })
+    };
+    syncMouthTunerControls();
+    setMouthTunerOpen(false);
+    setMouthTunerVisible(mouthTunerConfig.visible);
+    setMouthTunerStatus(mouthTunerConfig.enabled ? 'Override active' : 'Override disabled');
+
+    if (!mouthTunerConfig.visible) {
+      return;
+    }
+
+    mouthTunerToggleElement?.addEventListener('click', () => {
+      setMouthTunerOpen(!mouthTunerState?.open);
+    });
+    mouthTunerCloseElement?.addEventListener('click', () => {
+      setMouthTunerOpen(false);
+    });
+    mouthTunerEnableElement?.addEventListener('change', () => {
+      setMouthTunerEnabled(mouthTunerEnableElement.checked, {
+        immediate: true
+      });
+    });
+    mouthOpenElement?.addEventListener('input', () => {
+      applyMouthTunerValues({
+        mouthOpen: roundToStep(mouthOpenElement.value, 0.01)
+      }, {
+        immediate: true
+      });
+    });
+    mouthFormElement?.addEventListener('input', () => {
+      applyMouthTunerValues({
+        mouthForm: roundToStep(mouthFormElement.value, 0.01)
+      }, {
+        immediate: true
+      });
+    });
+    mouthNeutralElement?.addEventListener('click', () => {
+      applyMouthTunerValues({
+        mouthOpen: 0,
+        mouthForm: 0
+      }, {
+        immediate: true,
+        statusMessage: 'Neutral mouth'
+      });
+      setMouthTunerEnabled(true, {
+        immediate: true,
+        statusMessage: 'Override active'
+      });
+    });
+    mouthApplyIElement?.addEventListener('click', () => {
+      applyMouthTunerValues({
+        mouthOpen: 0.25,
+        mouthForm: 1
+      }, {
+        immediate: true,
+        statusMessage: 'Applied long I debug pose'
+      });
+      setMouthTunerEnabled(true, {
+        immediate: true,
+        statusMessage: 'Override active'
+      });
+    });
   }
 
   function normalizeLayoutTunerValues(input = {}) {
@@ -649,6 +1160,35 @@
     return clientX >= left && clientX <= right && clientY >= top && clientY <= bottom;
   }
 
+  function isPointInsideVisibleElement(element, clientX, clientY) {
+    if (!element || element.hidden) {
+      return false;
+    }
+    const style = window.getComputedStyle?.(element);
+    if (!style || style.display === 'none' || style.visibility === 'hidden') {
+      return false;
+    }
+    const rect = element.getBoundingClientRect?.();
+    if (!rect || rect.width <= 0 || rect.height <= 0) {
+      return false;
+    }
+    return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
+  }
+
+  function isPointInInteractiveUi(clientX, clientY) {
+    const interactiveElements = [
+      mouthTunerToggleElement,
+      mouthTunerPanelElement,
+      resizeModeCloseElement,
+      layoutTunerToggleElement,
+      dragZoneToggleElement,
+      document.body.classList.contains('layout-tuner-open') ? document.getElementById('layout-tuner-panel') : null,
+      document.body.classList.contains('drag-zone-panel-open') ? document.getElementById('drag-zone-panel') : null,
+      chatPanelElement?.classList.contains('visible') ? chatPanelElement : null
+    ];
+    return interactiveElements.some((element) => isPointInsideVisibleElement(element, clientX, clientY));
+  }
+
   function setWindowInteractivity(interactive) {
     if (typeof bridge?.sendWindowInteractivity !== 'function') {
       return;
@@ -670,7 +1210,10 @@
       setWindowInteractivity(false);
       return;
     }
-    setWindowInteractivity(isPointInCenterDragZone(position.clientX, position.clientY));
+    setWindowInteractivity(
+      isPointInCenterDragZone(position.clientX, position.clientY)
+      || isPointInInteractiveUi(position.clientX, position.clientY)
+    );
   }
 
   function clamp(value, min, max) {
@@ -695,7 +1238,7 @@
     const rawOpen = clamp(Number(mouthOpen) || 0, 0, 1);
     const rawForm = clamp(Number(mouthForm) || 0, -1, 1);
     const energy = clamp(Number(voiceEnergy) || 0, 0, 1);
-    const active = Boolean(speaking) && energy >= LIPSYNC_ACTIVE_ENERGY_MIN;
+    const active = Boolean(speaking);
     const intensity = clamp((energy - LIPSYNC_ACTIVE_ENERGY_MIN) / 0.08, 0, 1);
 
     if (!active) {
@@ -705,11 +1248,33 @@
       };
     }
 
-    const openGain = lerp(LIPSYNC_OPEN_GAIN_MIN, LIPSYNC_OPEN_GAIN_MAX, intensity);
-    const formGain = lerp(LIPSYNC_FORM_GAIN_MIN, LIPSYNC_FORM_GAIN_MAX, intensity);
-    const widenedOpen = Math.pow(rawOpen, LIPSYNC_OPEN_GAMMA) * openGain + Math.abs(rawForm) * 0.08 * intensity;
-    const boostedOpen = Math.max(clamp(widenedOpen, 0, 1), LIPSYNC_MIN_OPEN_WHEN_SPEAKING);
-    const boostedForm = clamp(rawForm * formGain, -1, 1);
+    lipsyncBaselineMouthOpen = clamp(
+      lipsyncBaselineMouthOpen + (rawOpen - lipsyncBaselineMouthOpen) * LIPSYNC_BASELINE_OPEN_ALPHA,
+      0,
+      1
+    );
+    lipsyncBaselineMouthForm = clamp(
+      lipsyncBaselineMouthForm + (rawForm - lipsyncBaselineMouthForm) * LIPSYNC_BASELINE_FORM_ALPHA,
+      -1,
+      1
+    );
+
+    const openGain = lerp(LIPSYNC_VARIANCE_OPEN_GAIN_MIN, LIPSYNC_VARIANCE_OPEN_GAIN_MAX, intensity);
+    const formGain = lerp(LIPSYNC_VARIANCE_FORM_GAIN_MIN, LIPSYNC_VARIANCE_FORM_GAIN_MAX, intensity);
+    const openDelta = rawOpen - lipsyncBaselineMouthOpen;
+    const formDelta = rawForm - lipsyncBaselineMouthForm;
+    const positiveOpenDelta = Math.max(0, openDelta) * openGain;
+    const negativeOpenDelta = Math.min(0, openDelta) * LIPSYNC_VARIANCE_OPEN_NEGATIVE_GAIN;
+    const speakingOpenFloor = clamp(lipsyncBaselineMouthOpen * LIPSYNC_SPEAKING_OPEN_FLOOR_RATIO, 0, 1);
+    const boostedOpen = clamp(
+      Math.max(
+        speakingOpenFloor,
+        lipsyncBaselineMouthOpen + positiveOpenDelta + negativeOpenDelta
+      ),
+      0,
+      1
+    );
+    const boostedForm = clamp(lipsyncBaselineMouthForm + formDelta * formGain, -1, 1);
 
     return {
       mouthOpen: boostedOpen,
@@ -873,17 +1438,13 @@
   }
 
   function resetLipsyncMouthState() {
-    lipsyncTargetMouthOpen = 0;
-    lipsyncTargetMouthForm = 0;
-    lipsyncCurrentMouthOpen = 0;
-    lipsyncCurrentMouthForm = 0;
+    syncLipsyncStateToDefaultMouthBasePose();
     lipsyncSpeakingActive = false;
   }
 
   function applyLipsyncValuesToModel({ source = 'unknown' } = {}) {
-    const coreModel = live2dModel?.internalModel?.coreModel;
-    if (!coreModel) {
-      return false;
+    if (getActiveMouthOverrideValues()) {
+      return applyActiveMouthOverrideForCurrentFrame();
     }
     const transitioned = typeof mouthTransitionApi?.stepMouthTransition === 'function'
       ? mouthTransitionApi.stepMouthTransition({
@@ -903,26 +1464,20 @@
       };
     lipsyncCurrentMouthOpen = clamp(Number(transitioned.mouthOpen) || 0, 0, 1);
     lipsyncCurrentMouthForm = clamp(Number(transitioned.mouthForm) || 0, -1, 1);
-    const mouthOpen = lipsyncCurrentMouthOpen;
-    const mouthForm = lipsyncCurrentMouthForm;
-    try {
-      if (typeof coreModel.addParameterValueById === 'function') {
-        coreModel.addParameterValueById('ParamMouthOpenY', mouthOpen, 1);
-        coreModel.addParameterValueById('ParamMouthForm', mouthForm, 1);
-      } else {
-        coreModel.setParameterValueById('ParamMouthOpenY', mouthOpen);
-        coreModel.setParameterValueById('ParamMouthForm', mouthForm);
-      }
-      return true;
-    } catch (err) {
+    const result = applyCompositeFacePoseToModel({
+      mouthOpen: lipsyncCurrentMouthOpen,
+      mouthForm: lipsyncCurrentMouthForm,
+      speaking: lipsyncSpeakingActive
+    });
+    if (!result.ok) {
       emitLipsyncTelemetry('frame.apply_failed', {
-        error: err?.message || String(err || 'unknown error'),
-        mouth_open: mouthOpen,
-        mouth_form: mouthForm,
+        error: result.error || 'apply_failed',
+        mouth_open: lipsyncCurrentMouthOpen,
+        mouth_form: lipsyncCurrentMouthForm,
         reason: `apply_${source}_failed`
       });
-      return false;
     }
+    return result.ok === true;
   }
 
   function detachLipsyncModelHook() {
@@ -1000,17 +1555,26 @@
     lipsyncApplyMode = 'raf_direct';
 
     if (live2dModel) {
-      try {
-        live2dModel.internalModel.coreModel.setParameterValueById('ParamMouthOpenY', 0);
-        live2dModel.internalModel.coreModel.setParameterValueById('ParamMouthForm', 0);
-        console.log('[lipsync] mouth parameters reset to neutral');
-        emitLipsyncTelemetry('sync.reset_neutral', { has_model: true, mouth_open: 0, mouth_form: 0, reason });
-      } catch (err) {
-        console.warn('[lipsync] Failed to reset mouth parameters:', err);
+      const basePose = getDefaultMouthBasePose();
+      const result = applyCompositeFacePoseToModel({
+        mouthOpen: basePose.mouthOpen,
+        mouthForm: basePose.mouthForm,
+        speaking: false
+      });
+      if (result.ok) {
+        console.log('[lipsync] mouth parameters reset to base pose');
+        emitLipsyncTelemetry('sync.reset_neutral', {
+          has_model: true,
+          mouth_open: basePose.mouthOpen,
+          mouth_form: basePose.mouthForm,
+          reason
+        });
+      } else {
+        console.warn('[lipsync] Failed to reset mouth parameters:', result.error || result.reason);
         emitLipsyncTelemetry('sync.reset_failed', {
           has_model: true,
           reason,
-          error: err?.message || String(err || 'unknown error')
+          error: result.error || result.reason || 'unknown error'
         });
       }
     }
@@ -1094,8 +1658,9 @@
       });
     }
     lipsyncState = null;
-    lipsyncTargetMouthOpen = 0;
-    lipsyncTargetMouthForm = 0;
+    const basePose = getDefaultMouthBasePose();
+    lipsyncTargetMouthOpen = basePose.mouthOpen;
+    lipsyncTargetMouthForm = basePose.mouthForm;
     lipsyncSpeakingActive = false;
     scheduleLipsyncRelease(stopState.reason);
     emitRendererDebug('lipsync.sync_stopped', {
@@ -1227,6 +1792,7 @@
 
       // Initialize lipsync state
       lipsyncState = lipsyncApi.createRuntimeState();
+      syncLipsyncStateToDefaultMouthBasePose();
       console.log('[lipsync] Runtime state created', { state: lipsyncState });
       emitLipsyncTelemetry('sync.runtime_ready', { has_state: !!lipsyncState });
       if (bindLipsyncModelHook()) {
@@ -1275,13 +1841,14 @@
         const paused = audioElement ? !!audioElement.paused : !speaking;
         const ended = audioElement ? !!audioElement.ended : false;
         const readyState = audioElement ? Number(audioElement.readyState) : null;
+        const basePose = getDefaultMouthBasePose();
         const frame = lipsyncApi.resolveVisemeFrame({
           frequencyBuffer: frequencyData,
           sampleRate: audioContext.sampleRate,
           voiceEnergy,
           speaking,
-          fallbackOpen: 0,
-          fallbackForm: 0,
+          fallbackOpen: basePose.mouthOpen,
+          fallbackForm: basePose.mouthForm,
           state: lipsyncState
         }) || {};
         const rawMouthOpen = clamp(Number(frame.mouthOpen) || 0, 0, 1);
@@ -1298,8 +1865,11 @@
         lipsyncTargetMouthForm = mouthForm;
         lipsyncSpeakingActive = speaking;
 
-        // Log every 30 frames (roughly once per second at 60fps)
-        if (frameCount % 30 === 0) {
+        const waveformCaptureConfig = getWaveformCaptureRuntimeConfig();
+        const captureEveryFrame = waveformCaptureConfig.enabled && waveformCaptureConfig.captureEveryFrame;
+
+        // Log every 30 frames (roughly once per second at 60fps) unless full waveform capture is enabled.
+        if (captureEveryFrame || frameCount % 30 === 0) {
           console.log('[lipsync] frame update', {
             frameCount,
             features: { energy: (Number(frame.features?.voiceEnergy) || voiceEnergy).toFixed(3) },
@@ -1337,6 +1907,17 @@
             ended,
             ready_state: readyState
           });
+          emitRendererDebug('mouth.frame_sample', {
+            request_id: activeVoiceRequestId,
+            frame: frameCount,
+            speaking,
+            voice_energy: Number(frame.features?.voiceEnergy) || voiceEnergy,
+            raw_mouth_open: rawMouthOpen,
+            raw_mouth_form: rawMouthForm,
+            mouth_open: mouthOpen,
+            mouth_form: mouthForm,
+            confidence: Number(frame.confidence) || 0
+          });
           if (speaking && voiceEnergy < 0.005) {
             emitRendererDebug('lipsync.frame_low_energy', {
               request_id: activeVoiceRequestId,
@@ -1355,7 +1936,7 @@
           applyLipsyncValuesToModel({ source: 'raf_direct' });
         }
         try {
-          if (frameCount % 60 === 0) {
+          if ((captureEveryFrame && waveformCaptureConfig.includeApplied) || frameCount % 60 === 0) {
             let appliedOpen = null;
             let appliedForm = null;
             try {
@@ -2301,6 +2882,16 @@
       throw createRpcError(-32602, 'param.set requires { name, value:number }');
     }
 
+    if (isMixableFaceParam(name)) {
+      const overlay = {};
+      if (name === 'ParamMouthForm') overlay.mouthForm = value;
+      if (name === 'ParamEyeLSmile') overlay.eyeSmileL = value;
+      if (name === 'ParamEyeRSmile') overlay.eyeSmileR = value;
+      if (name === 'ParamCheek') overlay.cheek = value;
+      setFaceBlendTarget(overlay);
+      return { ok: true, mixed: true };
+    }
+
     const coreModel = live2dModel.internalModel?.coreModel;
     if (!coreModel || typeof coreModel.setParameterValueById !== 'function') {
       throw createRpcError(-32005, 'setParameterValueById is unavailable on this model runtime');
@@ -2316,7 +2907,26 @@
       throw createRpcError(-32602, 'model.param.batchSet requires non-empty updates array');
     }
 
+    const mixedFaceTarget = {};
+    const directUpdates = [];
+
     for (const update of updates) {
+      const name = String(update?.name || '').trim();
+      const value = Number(update?.value);
+      if (isMixableFaceParam(name) && Number.isFinite(value)) {
+        if (name === 'ParamMouthForm') mixedFaceTarget.mouthForm = value;
+        if (name === 'ParamEyeLSmile') mixedFaceTarget.eyeSmileL = value;
+        if (name === 'ParamEyeRSmile') mixedFaceTarget.eyeSmileR = value;
+        if (name === 'ParamCheek') mixedFaceTarget.cheek = value;
+        continue;
+      }
+      directUpdates.push(update);
+    }
+
+    if (Object.keys(mixedFaceTarget).length > 0) {
+      setFaceBlendTarget(mixedFaceTarget);
+    }
+    for (const update of directUpdates) {
       setModelParam(update);
     }
     return {
@@ -2392,6 +3002,8 @@
       throw createRpcError(-32602, 'model.expression.set requires non-empty name');
     }
 
+    setFaceBlendTarget(mapExpressionNameToFaceBlendTarget(name), { replace: true });
+
     if (typeof live2dModel.expression === 'function') {
       live2dModel.expression(name);
       return { ok: true, name };
@@ -2411,6 +3023,8 @@
       return { ok: false, skipped: true, reason: 'model_not_loaded' };
     }
 
+    resetFaceBlendTarget();
+
     if (typeof live2dModel.resetExpression === 'function') {
       live2dModel.resetExpression();
       return { ok: true };
@@ -2423,6 +3037,15 @@
     }
 
     return { ok: false, skipped: true, reason: 'reset_expression_unavailable' };
+  }
+
+  function resetModelMouthPoseRaw() {
+    const basePose = getDefaultMouthBasePose();
+    return applyCompositeFacePoseToModel({
+      mouthOpen: basePose.mouthOpen,
+      mouthForm: basePose.mouthForm,
+      speaking: false
+    });
   }
 
   async function playModelMotion(params) {
@@ -2462,6 +3085,7 @@
         },
         afterIdleAction: async () => {
           resetModelExpressionRaw();
+          resetModelMouthPoseRaw();
         },
         maxQueueSize: Number(runtimeActionQueueConfig.maxQueueSize) || 120,
         overflowPolicy: runtimeActionQueueConfig.overflowPolicy || 'drop_oldest',
@@ -2488,7 +3112,24 @@
       lastError: state.lastError,
       layout: state.layout,
       windowState: state.windowState,
-      resizeModeEnabled: state.resizeModeEnabled
+      resizeModeEnabled: state.resizeModeEnabled,
+      debug: {
+        mouthOverride: {
+          enabled: externalMouthOverrideState.enabled === true,
+          values: normalizeMouthTunerValues(externalMouthOverrideState.values)
+        },
+        mouthTuner: {
+          visible: document.body.classList.contains('mouth-tuner-visible'),
+          open: mouthTunerState.open === true,
+          enabled: mouthTunerState.enabled === true,
+          values: normalizeMouthTunerValues(mouthTunerState.values)
+        },
+        waveformCapture: {
+          enabled: getWaveformCaptureRuntimeConfig().enabled,
+          captureEveryFrame: getWaveformCaptureRuntimeConfig().captureEveryFrame,
+          includeApplied: getWaveformCaptureRuntimeConfig().includeApplied
+        }
+      }
     };
   }
 
@@ -2681,6 +3322,8 @@
     state.modelLoaded = true;
     state.modelName = modelName || null;
     resetModelExpressionRaw();
+    resetModelMouthPoseRaw();
+    bindPersistentMouthOverrideHook();
   }
 
   function bindModelInteraction() {
@@ -3116,6 +3759,8 @@
       let result;
       if (method === 'state.get') {
         result = getState();
+      } else if (method === 'debug.mouthOverride.set') {
+        result = setExternalMouthOverride(params);
       } else if (method === 'param.set' || method === 'model.param.set') {
         result = setModelParam(params);
       } else if (method === 'model.param.batchSet') {
@@ -3205,6 +3850,7 @@
       const runtimeConfig = await bridge.getRuntimeConfig();
       runtimeUiConfig = runtimeConfig.uiConfig || null;
       runtimeLive2dPresets = runtimeConfig.live2dPresets || null;
+      initMouthTuner();
       initLayoutTuner();
       initDragZoneTuner();
       initChatPanel(runtimeUiConfig?.chat || {});

--- a/apps/desktop-live2d/renderer/index.html
+++ b/apps/desktop-live2d/renderer/index.html
@@ -92,6 +92,69 @@
         -webkit-app-region: no-drag;
       }
 
+      #mouth-tuner-toggle {
+        display: none;
+        position: fixed;
+        left: 12px;
+        bottom: 12px;
+        z-index: 30;
+        padding: 6px 10px;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        background: rgba(10, 14, 24, 0.66);
+        color: #dfe8ff;
+        font-size: 11px;
+        cursor: pointer;
+        -webkit-app-region: no-drag;
+      }
+
+      body.mouth-tuner-visible #mouth-tuner-toggle {
+        display: block;
+      }
+
+      #mouth-tuner-toggle:hover {
+        background: rgba(255, 255, 255, 0.14);
+      }
+
+      #mouth-tuner-panel {
+        display: none;
+        position: fixed;
+        left: 12px;
+        bottom: 52px;
+        z-index: 31;
+        width: 220px;
+        padding: 12px;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        background: rgba(10, 14, 24, 0.9);
+        color: #eff5ff;
+        box-shadow: 0 16px 36px rgba(0, 0, 0, 0.3);
+        backdrop-filter: blur(10px);
+        -webkit-app-region: no-drag;
+      }
+
+      body.mouth-tuner-visible.mouth-tuner-open #mouth-tuner-panel {
+        display: block;
+      }
+
+      .mouth-tuner-toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 12px;
+        gap: 10px;
+      }
+
+      .mouth-tuner-toggle-row label {
+        font-size: 11px;
+        color: #b8c6e8;
+      }
+
+      .mouth-tuner-checkbox {
+        width: 16px;
+        height: 16px;
+      }
+
       body.resize-mode-active #layout-tuner-toggle {
         display: block;
       }
@@ -467,6 +530,32 @@
     <div id="drag-handle"></div>
     <div id="stage"></div>
     <button id="resize-mode-close" type="button">Close Resize Mode</button>
+    <button id="mouth-tuner-toggle" type="button">Mouth Tuner</button>
+    <div id="mouth-tuner-panel">
+      <div class="layout-tuner-header">
+        <span class="layout-tuner-title">Mouth Tuner</span>
+        <button id="mouth-tuner-close" type="button" aria-label="Close mouth tuner">×</button>
+      </div>
+      <div class="mouth-tuner-toggle-row">
+        <label for="mouth-tuner-enable">Enable override</label>
+        <input class="mouth-tuner-checkbox" id="mouth-tuner-enable" type="checkbox" />
+      </div>
+      <div class="layout-tuner-row">
+        <label for="mouth-open">Mouth Open</label>
+        <span class="layout-tuner-value" id="mouth-open-value">0.00</span>
+        <input class="layout-tuner-slider" id="mouth-open" type="range" min="0" max="1" step="0.01" value="0" />
+      </div>
+      <div class="layout-tuner-row">
+        <label for="mouth-form">Mouth Form</label>
+        <span class="layout-tuner-value" id="mouth-form-value">0.00</span>
+        <input class="layout-tuner-slider" id="mouth-form" type="range" min="-1" max="1" step="0.01" value="0" />
+      </div>
+      <div class="layout-tuner-actions">
+        <button class="layout-tuner-action" id="mouth-neutral" type="button">Neutral</button>
+        <button class="layout-tuner-action" id="mouth-apply-i" type="button">Long I</button>
+      </div>
+      <div id="mouth-tuner-status" aria-live="polite"></div>
+    </div>
     <button id="layout-tuner-toggle" type="button">Adjust Layout</button>
     <button id="drag-zone-toggle" type="button">Adjust Drag Zone</button>
     <div id="drag-zone-visual"></div>

--- a/apps/desktop-live2d/renderer/lipsyncMouthTransition.js
+++ b/apps/desktop-live2d/renderer/lipsyncMouthTransition.js
@@ -1,13 +1,13 @@
 (function initLive2dMouthTransition(globalScope) {
   const DEFAULT_CONFIG = Object.freeze({
     open: {
-      attack: 0.4,
-      release: 0.24,
-      neutral: 0.12
+      attack: 0.56,
+      release: 0.3,
+      neutral: 0.16
     },
     form: {
-      attack: 0.34,
-      release: 0.22,
+      attack: 0.4,
+      release: 0.24,
       neutral: 0.14
     },
     settle: {

--- a/apps/desktop-live2d/renderer/lipsyncViseme.js
+++ b/apps/desktop-live2d/renderer/lipsyncViseme.js
@@ -9,26 +9,37 @@
       high: [3200, 5200]
     },
     smoothing: {
-      attack: 0.58,
-      release: 0.34
+      attack: 0.74,
+      release: 0.22
     },
     fallbackBlend: {
       min: 0.28,
       max: 0.9
     },
     visemeShape: {
-      sharpenPower: 1.55,
+      sharpenPower: 1.94,
       targets: {
-        a: { open: 0.98, form: -0.1 },
-        i: { open: 0.24, form: 0.92 },
-        u: { open: 0.34, form: -0.96 },
-        e: { open: 0.5, form: 0.42 },
-        o: { open: 0.72, form: -1 }
+        a: { open: 1.0, form: 0.38 },
+        i: { open: 0.24, form: 0.94 },
+        u: { open: 0.36, form: -0.8 },
+        e: { open: 0.52, form: 0.72 },
+        o: { open: 0.8, form: -0.92 }
       }
     },
+    articulation: {
+      minOpenScale: 0.7,
+      maxOpenScale: 1.22,
+      minFormScale: 0.7,
+      maxFormScale: 1.2,
+      lowEnergyBias: 0.62
+    },
     silence: {
-      energyThreshold: 0.045,
-      confidenceThreshold: 0.12
+      energyThreshold: 0.028,
+      confidenceThreshold: 0.08,
+      holdFrames: 4,
+      holdDecay: 0.74,
+      energyDrivenOpenFloor: 0.02,
+      energyDrivenOpenScale: 1.95
     }
   });
 
@@ -104,7 +115,9 @@
     return {
       previousSpectrum: null,
       smoothedWeights: createNeutralWeights(),
-      lastFeatures: null
+      lastFeatures: null,
+      lowSignalFrames: 0,
+      lastResolvedFrame: null
     };
   }
 
@@ -209,13 +222,15 @@
     const highMid = Number(features.highMid) || 0;
     const high = Number(features.high) || 0;
     const low = Number(features.low) || 0;
+    const openMidBias = Math.max(0, mid - low);
+    const openHighBias = Math.max(0, mid - lowMid);
 
     const scores = {
-      a: mid * 1.15 + lowMid * 0.72 + openness * 0.42 + voiceEnergy * 0.2 + (1 - Math.abs(features.spectralBalance || 0)) * 0.08,
-      i: highMid * 1.22 + high * 0.85 + spreadness * 0.38 + centroidNorm * 0.24 + flux * 0.12,
-      u: low * 1.18 + lowMid * 0.78 + roundness * 0.34 + (1 - brightness) * 0.18 + (1 - centroidNorm) * 0.12,
-      e: mid * 0.9 + highMid * 0.96 + spreadness * 0.34 + centroidNorm * 0.16 + flux * 0.1,
-      o: low * 1.02 + mid * 0.82 + roundness * 0.46 + openness * 0.16 + (1 - centroidNorm) * 0.14
+      a: mid * 1.22 + lowMid * 0.24 + openness * 0.38 + voiceEnergy * 0.2 + (1 - brightness) * 0.08 + openMidBias * 0.26 + openHighBias * 0.1 - roundness * 0.1,
+      i: high * 1.16 + highMid * 0.76 + spreadness * 0.32 + brightness * 0.16 + centroidNorm * 0.18 + flux * 0.08 - openness * 0.04,
+      u: low * 0.56 + lowMid * 1.12 + mid * 0.48 + roundness * 0.3 + openness * 0.08 + (1 - brightness) * 0.12 + (1 - centroidNorm) * 0.06,
+      e: high * 0.56 + highMid * 1.14 + mid * 0.52 + spreadness * 0.18 + brightness * 0.04 + openness * 0.18 + flux * 0.08,
+      o: low * 0.34 + mid * 1.02 + lowMid * 0.32 + openness * 0.22 + roundness * 0.46 + (1 - brightness) * 0.16 + (1 - centroidNorm) * 0.1 - spreadness * 0.06
     };
 
     return softmaxScores(scores);
@@ -259,8 +274,12 @@
   function deriveMouthParams(weights, features = {}, config = {}) {
     const safeWeights = normalizeWeights(weights);
     const visemeShape = config.visemeShape || DEFAULT_CONFIG.visemeShape;
+    const articulationConfig = config.articulation || DEFAULT_CONFIG.articulation;
     const targets = visemeShape.targets || DEFAULT_CONFIG.visemeShape.targets;
     const shapedWeights = sharpenWeights(safeWeights, visemeShape.sharpenPower);
+    const voiceEnergy = clamp(Number(features.voiceEnergy) || 0, 0, 1);
+    const opennessHint = clamp(Number(features.opennessHint) || 0, 0, 1);
+    const spectralBalance = clamp(Number(features.spectralBalance) || 0, -1, 1);
     let mouthOpen = 0;
     let mouthForm = 0;
 
@@ -270,15 +289,24 @@
       mouthForm += shapedWeights[name] * clamp(Number(target.form) || 0, -1, 1);
     }
 
+    const articulation = clamp(
+      voiceEnergy * articulationConfig.lowEnergyBias
+      + opennessHint * 0.28
+      + Math.abs(spectralBalance) * 0.22,
+      0,
+      1
+    );
+    const openScale = lerp(articulationConfig.minOpenScale, articulationConfig.maxOpenScale, articulation);
+    const formScale = lerp(articulationConfig.minFormScale, articulationConfig.maxFormScale, articulation);
     mouthOpen = clamp(
-      mouthOpen
-      + (Number(features.voiceEnergy) || 0) * 0.08
-      + Math.max(0, (Number(features.opennessHint) || 0) - 0.45) * 0.08,
+      mouthOpen * openScale
+      + voiceEnergy * 0.12
+      + Math.max(0, opennessHint - 0.36) * 0.11,
       0,
       1
     );
     mouthForm = clamp(
-      mouthForm + (Number(features.spectralBalance) || 0) * 0.06,
+      (mouthForm + spectralBalance * 0.08) * formScale,
       -1,
       1
     );
@@ -304,7 +332,50 @@
     const smoothedWeights = smoothWeights(targetWeights, state, input.config);
     const derived = deriveMouthParams(smoothedWeights, features, input.config);
     const confidence = speaking ? computeConfidence(features) : 0;
+    const holdFrames = Math.max(0, Number(silenceConfig.holdFrames) || 0);
+    const holdDecay = clamp(Number(silenceConfig.holdDecay) || 0.82, 0, 1);
+    const energyDrivenOpenFloor = clamp(Number(silenceConfig.energyDrivenOpenFloor) || 0, 0, 1);
+    const energyDrivenOpenScale = Math.max(0, Number(silenceConfig.energyDrivenOpenScale) || 0);
     if (rawVoiceEnergy < silenceConfig.energyThreshold || confidence < silenceConfig.confidenceThreshold) {
+      const canHoldPreviousFrame = (
+        speaking
+        && holdFrames > 0
+        && state.lastResolvedFrame
+        && state.lowSignalFrames < holdFrames
+      );
+      if (canHoldPreviousFrame) {
+        state.lowSignalFrames += 1;
+        const heldFrame = state.lastResolvedFrame;
+        const decay = Math.pow(holdDecay, state.lowSignalFrames);
+        return {
+          confidence: clamp((Number(heldFrame.confidence) || 0) * decay, 0, 1),
+          features,
+          weights: normalizeWeights(heldFrame.weights || state.smoothedWeights || createNeutralWeights()),
+          dominantViseme: heldFrame.dominantViseme || 'a',
+          mouthOpen: clamp(lerp(fallbackOpen * 0.5, Number(heldFrame.mouthOpen) || 0, decay), 0, 1),
+          mouthForm: clamp(lerp(fallbackForm * 0.5, Number(heldFrame.mouthForm) || 0, decay), -1, 1)
+        };
+      }
+      const canUseEnergyDrivenFallback = speaking && rawVoiceEnergy >= Math.max(0.016, Number(silenceConfig.energyThreshold) * 0.7);
+      if (canUseEnergyDrivenFallback) {
+        const previousForm = Number(state.lastResolvedFrame?.mouthForm) || fallbackForm;
+        const drivenOpen = clamp(
+          energyDrivenOpenFloor + rawVoiceEnergy * energyDrivenOpenScale,
+          0,
+          0.12
+        );
+        const drivenForm = clamp(previousForm * 0.45, -1, 1);
+        return {
+          confidence: clamp(confidence * 0.6, 0, 1),
+          features,
+          weights: normalizeWeights(state.smoothedWeights || createNeutralWeights()),
+          dominantViseme: state.lastResolvedFrame?.dominantViseme || 'a',
+          mouthOpen: Math.max(drivenOpen, fallbackOpen * 0.18),
+          mouthForm: drivenForm
+        };
+      }
+      state.lowSignalFrames = 0;
+      state.lastResolvedFrame = null;
       state.smoothedWeights = createNeutralWeights();
       return {
         confidence: 0,
@@ -315,28 +386,37 @@
         mouthForm: 0
       };
     }
-    const fallbackBlend = lerp(
-      DEFAULT_CONFIG.fallbackBlend.min,
-      DEFAULT_CONFIG.fallbackBlend.max,
-      confidence
-    );
-
     const visemeBlend = lerp(
-      DEFAULT_CONFIG.fallbackBlend.min,
-      Math.max(DEFAULT_CONFIG.fallbackBlend.max, 0.94),
+      DEFAULT_CONFIG.fallbackBlend.min + 0.06,
+      Math.max(DEFAULT_CONFIG.fallbackBlend.max, 0.98),
       confidence
     );
+    const openVisemeBlend = speaking
+      ? clamp(Math.max(0.68, visemeBlend + 0.16), 0, 1)
+      : visemeBlend;
+    const formVisemeBlend = speaking
+      ? clamp(Math.max(0.5, visemeBlend), 0, 1)
+      : visemeBlend;
 
-    return {
+    const resolvedFrame = {
       confidence,
       features,
       weights: smoothedWeights,
       dominantViseme: VISEME_NAMES.reduce((best, name) => (
         smoothedWeights[name] > smoothedWeights[best] ? name : best
       ), 'a'),
-      mouthOpen: clamp(lerp(fallbackOpen * 0.4, derived.mouthOpen, visemeBlend), 0, 1),
-      mouthForm: clamp(lerp(fallbackForm * 0.35, derived.mouthForm, visemeBlend), -1, 1)
+      mouthOpen: clamp(lerp(fallbackOpen * 0.22, derived.mouthOpen, openVisemeBlend), 0, 1),
+      mouthForm: clamp(lerp(fallbackForm * 0.3, derived.mouthForm, formVisemeBlend), -1, 1)
     };
+    state.lowSignalFrames = 0;
+    state.lastResolvedFrame = {
+      confidence: resolvedFrame.confidence,
+      weights: cloneWeights(resolvedFrame.weights),
+      dominantViseme: resolvedFrame.dominantViseme,
+      mouthOpen: resolvedFrame.mouthOpen,
+      mouthForm: resolvedFrame.mouthForm
+    };
+    return resolvedFrame;
   }
 
   const api = {

--- a/apps/desktop-live2d/shared/defaultUiConfig.js
+++ b/apps/desktop-live2d/shared/defaultUiConfig.js
@@ -86,6 +86,17 @@
     interaction: Object.freeze({
       dragZone: DEFAULT_DRAG_ZONE_CONFIG
     }),
+    debug: Object.freeze({
+      mouthTuner: Object.freeze({
+        visible: false,
+        enabled: false
+      }),
+      waveformCapture: Object.freeze({
+        enabled: false,
+        captureEveryFrame: true,
+        includeApplied: true
+      })
+    }),
     layout: DEFAULT_LAYOUT_CONFIG,
     chat: Object.freeze({
       panel: Object.freeze({

--- a/docs/LIPSYNC_CONFLICT_DEBUG_GUIDE.md
+++ b/docs/LIPSYNC_CONFLICT_DEBUG_GUIDE.md
@@ -1,5 +1,7 @@
 # 嘴形同步与表情动作冲突调试指南
 
+> 历史文档。主要记录 2026-03-01 左右的旧排查过程，不代表当前主线实现。当前 lipsync 链路、face mixer、waveform recorder，请以 `docs/VOICE_LIPSYNC_DEBUG_GUIDE.md` 和 `docs/process/desktop-live2d-lipsync-waveform-tuning-log.md` 为准。
+
 ## 已添加的调试日志
 
 我已经在 `apps/desktop-live2d/renderer/bootstrap.js` 中添加了以下调试日志：

--- a/docs/LIPSYNC_CONFLICT_SUMMARY.md
+++ b/docs/LIPSYNC_CONFLICT_SUMMARY.md
@@ -1,5 +1,7 @@
 # 嘴形同步与表情动作冲突问题 - 调查总结
 
+> 历史文档。主要记录 2026-03-01 左右的旧冲突调查，不代表当前主线 lipsync/face mixer 实现。现状请看 `docs/VOICE_LIPSYNC_DEBUG_GUIDE.md`。
+
 ## 问题描述
 
 当 yachiyo 说完话后，可能由于嘴形和动作的冲突，yachiyo 不会响应其他表情动作（如笑、哭）。

--- a/docs/LIPSYNC_EXPRESSION_CONFLICT_INVESTIGATION.md
+++ b/docs/LIPSYNC_EXPRESSION_CONFLICT_INVESTIGATION.md
@@ -1,5 +1,7 @@
 # 嘴形同步与表情动作冲突问题调查方案
 
+> 历史文档。该方案对应旧版冲突排查阶段，未覆盖当前主线的 face mixer 与 waveform recorder。现状请看 `docs/VOICE_LIPSYNC_DEBUG_GUIDE.md` 和 `docs/process/desktop-live2d-lipsync-waveform-tuning-log.md`。
+
 版本：v1
 日期：2026-03-01
 分支：`integration/voice-lipsync`

--- a/docs/VOICE_LIPSYNC_DEBUG_GUIDE.md
+++ b/docs/VOICE_LIPSYNC_DEBUG_GUIDE.md
@@ -1,243 +1,222 @@
 # Voice Lipsync 调试指南
 
-## 概述
+本文档只描述当前主线可执行的 lipsync 调试方式。
 
-本指南帮助调试 API 语音播放时的口型同步功能。
+如果你要看最近一轮嘴形调参与 waveform recorder 的开发经过，另见：
+- `docs/process/desktop-live2d-lipsync-waveform-tuning-log.md`
 
-## 架构说明
+## 1. 当前链路
 
-### 数据流
+### 1.1 入口
 
-```
-Runtime (voice.requested event)
-  ↓
-Desktop Main (processVoiceRequestedOnDesktop)
-  ↓ qwenTtsClient.synthesizeNonStreaming()
-  ↓ qwenTtsClient.fetchAudioBuffer()
-  ↓ IPC: desktop:voice:play-memory
-  ↓
-Renderer (playVoiceFromBase64)
-  ↓ startLipsync(systemAudio)
-  ↓ AudioContext + AnalyserNode
-  ↓ requestAnimationFrame loop
-  ↓ Live2DVisemeLipSync API
-  ↓ Live2D Model Parameters
-```
+1. runtime
+   - `apps/runtime/tooling/adapters/voice.js`
+   - `ttsAliyunVc()`
+   - 当 `voice.path = electron_native` 时发布 `voice.requested`
+2. desktop main
+   - `apps/desktop-live2d/main/desktopSuite.js`
+   - `processVoiceRequestedOnDesktop()`
+3. renderer
+   - `apps/desktop-live2d/renderer/bootstrap.js`
+   - `playVoiceFromRemote()`
+   - `playVoiceFromBase64()`
+   - `startRealtimeVoicePlayback()`
+   - `startLipsync()`
 
-### 关键组件
+### 1.2 嘴形内部链
 
-1. **QwenTtsClient** (`apps/desktop-live2d/main/voice/qwenTtsClient.js`)
-   - 调用 DashScope API 获取语音
-   - 返回 audioUrl 和 mimeType
+1. `lipsyncViseme.js`
+   - `resolveVisemeFrame()`
+   - 生成 `raw_mouth_open` / `raw_mouth_form`
+2. `bootstrap.js`
+   - `enhanceMouthParams()`
+   - speaking 增益、低能量豁免、face mixer 输入
+3. `lipsyncMouthTransition.js`
+   - `stepMouthTransition()`
+   - attack / release / neutral 过渡
+4. `bootstrap.js`
+   - 最终写入 `ParamMouthOpenY` / `ParamMouthForm`
 
-2. **processVoiceRequestedOnDesktop** (`apps/desktop-live2d/main/desktopSuite.js`)
-   - 处理 `voice.requested` 事件
-   - 下载音频并转换为 base64
-   - 通过 IPC 发送到渲染进程
+## 2. 当前推荐的调试方式
 
-3. **playVoiceFromBase64** (`apps/desktop-live2d/renderer/bootstrap.js`)
-   - 解码 base64 音频
-   - 创建 Blob 和 ObjectURL
-   - 调用 startLipsync()
-   - 播放音频
-
-4. **startLipsync** (`apps/desktop-live2d/renderer/bootstrap.js`)
-   - 创建 AudioContext 和 AnalyserNode
-   - 连接音频节点
-   - 启动 requestAnimationFrame 循环
-   - 使用 Live2DVisemeLipSync API 分析音频
-   - 更新 Live2D 模型参数
-
-5. **Live2DVisemeLipSync** (`apps/desktop-live2d/renderer/lipsyncViseme.js`)
-   - 提取音频特征
-   - 推断口型权重
-   - 计算嘴部参数
-   - 平滑处理
-
-## 调试步骤
-
-### 1. 启动 Desktop 应用
-
-```bash
-cd /Users/doosam/.openclaw/workspace/yachiyo-desktop-dev/desktop-ai-native-runtime-issue30
-npm run desktop:up
-```
-
-### 2. 打开开发者工具
-
-在 Desktop 窗口中按 `Cmd+Option+I` (macOS) 或 `Ctrl+Shift+I` (Windows/Linux)
-
-### 3. 运行测试脚本
-
-```bash
-node scripts/test-voice-lipsync.js
-```
-
-### 4. 观察控制台日志
-
-在 DevTools 的 Console 标签中，过滤 `lipsync` 关键字。
-
-### 5. 使用 SSE 调试器追踪口型管理器调用
-
-先开启 Debug Stream：
+### 2.1 开启 Debug Stream
 
 ```bash
 curl -s -X PUT http://127.0.0.1:3000/api/debug/mode \
   -H "content-type: application/json" \
-  -d '{"debug":true}' | jq
+  -d '{"debug":true}'
 ```
 
-然后在单独终端订阅口型链路 topic（按文档规范使用精确 topic）：
+### 2.2 订阅关键 topic
+
+优先看这组：
 
 ```bash
-curl -N "http://127.0.0.1:3000/api/debug/events?topics=chain.renderer.bootstrap.start,chain.renderer.bootstrap.failed,chain.renderer.voice_memory.listener_registered,chain.renderer.voice_memory.listener_missing,chain.renderer.voice_memory.received,chain.renderer.voice_memory.playback_enter,chain.renderer.voice_memory.source_ready,chain.renderer.voice_memory.play_attempt,chain.renderer.voice_memory.playback_started,chain.renderer.voice_memory.play_rejected,chain.renderer.voice_memory.audio_event,chain.renderer.voice_memory.lipsync_started,chain.renderer.voice_memory.lipsync_inactive,chain.renderer.voice_memory.lipsync_failed,chain.renderer.voice_memory.playback_failed,chain.renderer.voice_memory.failed,chain.electron.voice.requested,chain.electron.voice.duplicate_ignored,chain.electron.voice.synthesis.completed,chain.electron.voice.ipc.dispatched,chain.electron.voice.failed,chain.lipsync.playback.requested,chain.lipsync.playback.decoded,chain.lipsync.playback.source_ready,chain.lipsync.playback.started,chain.lipsync.playback.ended,chain.lipsync.playback.error,chain.lipsync.playback.invalid_payload,chain.lipsync.playback.interrupted,chain.lipsync.playback.lipsync_inactive,chain.lipsync.sync.start,chain.lipsync.sync.unavailable,chain.lipsync.sync.audio_context_ready,chain.lipsync.sync.audio_context_resumed,chain.lipsync.sync.graph_ready,chain.lipsync.sync.runtime_ready,chain.lipsync.sync.loop_started,chain.lipsync.sync.loop_stopped,chain.lipsync.sync.loop_cancelled,chain.lipsync.sync.reset_neutral,chain.lipsync.sync.reset_failed,chain.lipsync.sync.failed,chain.lipsync.sync.stop,chain.lipsync.frame.sample,chain.lipsync.frame.apply_failed"
+curl -N "http://127.0.0.1:3000/api/debug/events?topics=chain.electron.notification.received,chain.renderer.voice_memory.received,chain.renderer.voice_remote.received,chain.renderer.voice_stream.start_received,chain.renderer.voice_stream.chunk,chain.renderer.mouth.frame_sample,chain.renderer.lipsync.frame_applied"
 ```
 
-关注字段：
+必要时再补：
 
-1. `request_id`：串联一轮 voice 播放与口型调用。
-2. `event/topic`：确认中断点发生在哪个阶段。
-3. `has_lipsync_api`、`has_model`、`has_audio_context`、`has_analyser`：快速判断依赖是否就绪。
-4. `voice_energy`、`mouth_open`、`mouth_form`：确认口型管理器是否在持续输出帧。
-
-推荐判定顺序：
-
-1. 有 `chain.electron.voice.ipc.dispatched` 但没有 `chain.renderer.voice_memory.received`：渲染层未收到 `desktop:voice:play-memory`。
-2. 有 `chain.renderer.voice_memory.received` 但没有 `chain.lipsync.playback.requested`：渲染层回调触发了，但口型链路没有进入 `playVoiceFromBase64`。
-3. 有 `chain.lipsync.sync.start` 但出现 `chain.lipsync.sync.unavailable`：API 或模型未就绪。
-4. 有 `chain.lipsync.sync.runtime_ready` 但没有 `chain.lipsync.frame.sample`：动画循环未真正运行。
-5. `chain.lipsync.frame.sample` 正常出现但视觉无口型：检查模型参数映射（`ParamMouthOpenY` / `ParamMouthForm`）或后续覆盖。
-
-## 预期日志流
-
-### 正常情况
-
-```
-[lipsync] playVoiceFromBase64 called {hasBase64: true, base64Length: 123456, mimeType: "audio/ogg", hasLipsyncApi: true, hasModel: true}
-[lipsync] Audio decoded {binaryLength: 92592, bytesLength: 92592}
-[lipsync] Audio source set, starting lipsync
-[lipsync] startLipsync called {hasLipsyncApi: true, hasModel: true, hasAudioElement: true, audioSrc: "blob:..."}
-[lipsync] AudioContext created {sampleRate: 48000, state: "running"}
-[lipsync] Audio nodes connected {fftSize: 2048, frequencyBinCount: 1024, smoothingTimeConstant: 0.8}
-[lipsync] Runtime state created {state: {...}}
-[lipsync] Animation loop started
-[lipsync] Audio playback started
-[lipsync] frame update {frameCount: 0, features: {energy: "0.234"}, weights: {a: "0.45", i: "0.12", u: "0.23"}, mouthParams: {openY: "0.456", form: "0.123"}, frame: {openY: "0.456", form: "0.123"}}
-[lipsync] frame update {frameCount: 30, ...}
-[lipsync] frame update {frameCount: 60, ...}
-...
-[lipsync] stopLipsync called {hasAnimationFrame: true, hasState: true, hasModel: true, hasAudioContext: true}
-[lipsync] animation frame cancelled
-[lipsync] mouth parameters reset to neutral
+```bash
+curl -N "http://127.0.0.1:3000/api/debug/events?topics=chain.renderer.voice_memory.playback_started,chain.renderer.voice_remote.playback_started,chain.renderer.voice_stream.playback_started,chain.renderer.voice_memory.lipsync_started,chain.renderer.voice_remote.lipsync_started,chain.renderer.voice_stream.lipsync_started"
 ```
 
-## 常见问题诊断
+### 2.3 当前最重要的两个 topic
 
-### 问题 1: 没有看到任何 [lipsync] 日志
+- `chain.renderer.mouth.frame_sample`
+  - 观察目标嘴形
+  - 字段：
+    - `raw_mouth_open`
+    - `raw_mouth_form`
+    - `mouth_open`
+    - `mouth_form`
+    - `voice_energy`
+    - `confidence`
 
-**可能原因:**
-- 语音请求没有触发
-- IPC 通信失败
-- 渲染进程没有收到 `desktop:voice:play-memory` 事件
+- `chain.renderer.lipsync.frame_applied`
+  - 观察最终回读值
+  - 字段：
+    - `target_mouth_open`
+    - `target_mouth_form`
+    - `applied_mouth_open`
+    - `applied_mouth_form`
+    - `apply_mode`
 
-**检查:**
-1. 查看主进程日志（终端输出）
-2. 检查是否有 `[desktop-live2d] voice requested process failed` 错误
-3. 检查 `DASHSCOPE_API_KEY` 是否配置
+调试顺序：
 
-### 问题 2: 看到 `hasLipsyncApi: false`
+1. 先看 `mouth.frame_sample`
+   - 确认上游有没有输出有效 `open/form`
+2. 再看 `frame_applied`
+   - 确认最终落模值是否和目标值一致
+3. 如果两者不一致
+   - 问题在 final write / mixer / 模型覆盖
+4. 如果两者一致但视觉仍不明显
+   - 问题更偏模型资源、参数映射或 motion 干扰
 
-**可能原因:**
-- `lipsyncViseme.js` 没有加载
-- `window.Live2DVisemeLipSync` 未定义
+## 3. 逐帧 waveform 记录
 
-**检查:**
-1. 确认 `apps/desktop-live2d/renderer/index.html` 中有 `<script src="./lipsyncViseme.js"></script>`
-2. 在 Console 中输入 `window.Live2DVisemeLipSync` 检查是否存在
+### 3.1 配置
 
-### 问题 3: 看到 `hasModel: false`
+`desktop-live2d.json`：
 
-**可能原因:**
-- Live2D 模型还未加载
-- 模型加载失败
-
-**检查:**
-1. 查看是否有模型加载错误
-2. 在 Console 中输入 `live2dModel` 检查模型对象
-
-### 问题 4: AudioContext 创建失败
-
-**可能原因:**
-- 浏览器安全策略限制
-- 已经创建过 MediaElementSource
-
-**检查:**
-1. 查看错误信息
-2. 可能需要在用户交互后才能创建 AudioContext
-
-### 问题 5: 看到日志但没有口型动作
-
-**可能原因:**
-- Live2D 模型参数名称不匹配
-- 参数值范围不正确
-- 模型没有嘴部参数
-
-**检查:**
-1. 查看 `frame update` 日志中的 `openY` 和 `form` 值
-2. 在 Console 中手动设置参数测试:
-   ```javascript
-   live2dModel.internalModel.coreModel.setParameterValueById('ParamMouthOpenY', 1.0);
-   live2dModel.internalModel.coreModel.setParameterValueById('ParamMouthForm', 0.5);
-   ```
-3. 检查模型是否有这些参数:
-   ```javascript
-   live2dModel.internalModel.coreModel.getParameterIds();
-   ```
-
-### 问题 6: 音频播放但立即停止口型
-
-**可能原因:**
-- `stopLipsync()` 被过早调用
-- 动画循环被中断
-
-**检查:**
-1. 查看 `stopLipsync called` 日志的时间
-2. 检查是否有其他代码调用了 `stopLipsync()`
-
-## 手动测试
-
-在 DevTools Console 中执行:
-
-```javascript
-// 1. 检查 API 是否可用
-console.log('Lipsync API:', window.Live2DVisemeLipSync);
-console.log('Model:', live2dModel);
-
-// 2. 测试手动设置参数
-live2dModel.internalModel.coreModel.setParameterValueById('ParamMouthOpenY', 1.0);
-live2dModel.internalModel.coreModel.setParameterValueById('ParamMouthForm', 0.5);
-
-// 3. 重置参数
-live2dModel.internalModel.coreModel.setParameterValueById('ParamMouthOpenY', 0);
-live2dModel.internalModel.coreModel.setParameterValueById('ParamMouthForm', 0);
-
-// 4. 查看所有参数
-live2dModel.internalModel.coreModel.getParameterIds();
+```json
+{
+  "debug": {
+    "waveformCapture": {
+      "enabled": true,
+      "captureEveryFrame": true,
+      "includeApplied": true
+    }
+  }
+}
 ```
 
-## 下一步
+### 3.2 输出目录
 
-如果以上步骤都正常但仍然没有口型，可能需要:
+- `~/yachiyo/data/desktop-live2d/mouth-waveforms`
 
-1. 检查 Live2D 模型的参数映射
-2. 调整口型参数的计算逻辑
-3. 检查是否有其他代码覆盖了嘴部参数
-4. 验证音频分析是否正确提取特征
+文件格式：
+- 每次 voice request 生成一份 `<timestamp>-<request_id>.jsonl`
 
-## 相关文件
+每行一条事件，当前主要有：
+- `chain.renderer.mouth.frame_sample`
+- `chain.renderer.lipsync.frame_applied`
 
-- `apps/desktop-live2d/main/voice/qwenTtsClient.js` - TTS 客户端
-- `apps/desktop-live2d/main/desktopSuite.js` - 主进程事件处理
-- `apps/desktop-live2d/renderer/bootstrap.js` - 渲染进程口型同步
-- `apps/desktop-live2d/renderer/lipsyncViseme.js` - 口型分析 API
-- `scripts/test-voice-lipsync.js` - 测试脚本
+### 3.3 为什么推荐用 waveform 文件
+
+SSE 更适合在线追踪。  
+如果要看完整波形、做图、比对 `target/applied`，应优先看 JSONL 文件。
+
+## 4. 常见定位路径
+
+### 4.1 有声音但嘴几乎不动
+
+优先检查：
+
+1. `chain.renderer.mouth.frame_sample`
+   - `mouth_open` 是否长期接近 `0`
+2. `voice_energy`
+   - 是否长期极低
+3. `confidence`
+   - 是否长期偏低，导致 `resolveVisemeFrame()` 太保守
+
+常见根因：
+- `resolveVisemeFrame()` 的 speaking blend 太保守
+- speaking 弱音节被过早回落
+- 最终 transition 把目标值吃掉
+
+### 4.2 目标值有变化，但最后模型还是闭嘴
+
+优先检查：
+
+1. `chain.renderer.lipsync.frame_applied`
+2. 比较：
+   - `target_mouth_open`
+   - `applied_mouth_open`
+   - `target_mouth_form`
+   - `applied_mouth_form`
+
+如果明显不一致：
+- 优先怀疑 face mixer
+- `beforeModelUpdate` 写入顺序
+- expression / motion 对同参数的覆盖
+
+### 4.3 嘴形和表情互相打架
+
+当前主线已引入最小版 face mixer。  
+如果仍出现冲突，先确认：
+
+1. speaking 时 `target_mouth_form` 正常
+2. `applied_mouth_form` 是否被顶到极值
+3. 是否正好叠了 `greet` / `smile` / `param_batch`
+
+### 4.4 realtime 和 non-streaming 表现不一样
+
+这是正常现象，先分链路看：
+
+- `desktop:voice:play-memory`
+- `desktop:voice:play-remote`
+- `desktop:voice:stream-start/chunk/end`
+
+realtime 额外要看：
+- chunk 边界
+- prebuffer
+- idle timeout
+- speaking 判定是否过早掉线
+
+## 5. 手工检查建议
+
+### 5.1 先跑一轮语音
+
+```bash
+npm run desktop:up
+```
+
+然后通过 WebUI 或 `/ws` 触发一段固定文案。
+
+### 5.2 再看最新 waveform 文件
+
+```bash
+ls -lt ~/yachiyo/data/desktop-live2d/mouth-waveforms | head
+```
+
+### 5.3 再做图
+
+如果已经有逐帧 JSONL，后续分析优先基于文件画图，而不是只看抽样日志。
+
+## 6. 相关文件
+
+- `apps/runtime/tooling/adapters/voice.js`
+- `apps/desktop-live2d/main/desktopSuite.js`
+- `apps/desktop-live2d/main/config.js`
+- `apps/desktop-live2d/renderer/bootstrap.js`
+- `apps/desktop-live2d/renderer/lipsyncViseme.js`
+- `apps/desktop-live2d/renderer/lipsyncMouthTransition.js`
+- `scripts/test-voice-lipsync.js`
+
+## 7. 历史文档说明
+
+以下文档仍可参考调查思路，但不代表当前主线实现：
+- `docs/LIPSYNC_CONFLICT_DEBUG_GUIDE.md`
+- `docs/LIPSYNC_CONFLICT_SUMMARY.md`
+- `docs/LIPSYNC_EXPRESSION_CONFLICT_INVESTIGATION.md`

--- a/docs/modules/desktop-live2d/README.md
+++ b/docs/modules/desktop-live2d/README.md
@@ -1,9 +1,22 @@
 # Desktop Live2D 模块文档索引
 
+- 全局运行时配置总表：`docs/modules/runtime/config-reference.md`
 - 模块级细粒度文档：`docs/modules/desktop-live2d/module-reference.md`
+- 配置参考：`docs/modules/desktop-live2d/desktop-live2d-config-reference.md`
 - Motion/Expression 资产补全文档：`docs/modules/desktop-live2d/model-motion-expression-assets.md`
+- Voice/Lipsync 调试指南：`docs/VOICE_LIPSYNC_DEBUG_GUIDE.md`
 - 施工与阶段计划：`docs/DESKTOP_LIVE2D_CONSTRUCTION_PLAN.md`
 - 开发与排障日志：`docs/process/desktop-live2d-resize-dragzone-debug-log.md`
+- Lipsync 开发日志：`docs/process/desktop-live2d-lipsync-waveform-tuning-log.md`
+
+历史调查文档：
+- `docs/LIPSYNC_CONFLICT_DEBUG_GUIDE.md`
+- `docs/LIPSYNC_CONFLICT_SUMMARY.md`
+- `docs/LIPSYNC_EXPRESSION_CONFLICT_INVESTIGATION.md`
+
+说明：
+- 上述历史文档保留了 2026-03-01 左右的排查过程，但不再代表当前主线实现。
+- 当前嘴形链路、face mixer、逐帧 waveform 采集，以 `VOICE_LIPSYNC_DEBUG_GUIDE.md` 和 `desktop-live2d-lipsync-waveform-tuning-log.md` 为准。
 
 建议阅读顺序：
 1. `module-reference.md` 第 2 章（端到端调用链）

--- a/docs/modules/desktop-live2d/desktop-live2d-config-reference.md
+++ b/docs/modules/desktop-live2d/desktop-live2d-config-reference.md
@@ -1,0 +1,298 @@
+# Desktop Live2D 配置参考
+
+本文档只覆盖 `desktop-live2d.json` 这一份 UI/runtime 配置。
+
+如果你要看当前项目的全部运行时配置总表，另见：
+
+- `docs/modules/runtime/config-reference.md`
+
+核查范围基于当前代码：
+- 运行时配置文件：`~/yachiyo/config/desktop-live2d.json`
+- 首次启动模板：`config/desktop-live2d.json`
+- 配置加载入口：`apps/desktop-live2d/main/config.js`
+
+## 1. 真实生效文件与加载链
+
+### 1.1 文件位置
+
+- 真正运行时读取的是 `~/yachiyo/config/desktop-live2d.json`
+- 仓库内的 `config/desktop-live2d.json` 只是首次启动复制模板
+- gateway 的只读配置接口 `/api/config/desktop-live2d/raw` 现在也返回运行时文件，而不是模板
+
+### 1.2 加载链
+
+1. `apps/desktop-live2d/main/config.js`
+   - `resolveDesktopLive2dConfig()`
+   - `loadDesktopLive2dUiConfig()`
+   - `parseJsonWithComments()`
+   - `normalizeUiConfig()`
+2. `apps/desktop-live2d/main/desktopSuite.js`
+   - `startDesktopSuite()` 读取 `config.uiConfig`
+   - 创建 avatar/chat/bubble 窗口
+   - 通过 `ipcMain.handle(CHANNELS.getRuntimeConfig, ...)` 把 `uiConfig` 发给 renderer
+3. `apps/desktop-live2d/main/preload.js`
+   - `getRuntimeConfig()`
+4. `apps/desktop-live2d/renderer/bootstrap.js`
+   - `bridge.getRuntimeConfig()`
+   - `runtimeUiConfig = runtimeConfig.uiConfig || null`
+   - 后续 renderer 逻辑从 `runtimeUiConfig` 取配置
+
+补充事实：
+
+- `DESKTOP_LIVE2D_CONFIG_PATH` 可以覆盖默认路径；默认仍是 `~/yachiyo/config/desktop-live2d.json`
+- `normalizeUiConfig()` 只保留当前 schema 已定义字段；额外字段不会进入运行时 `uiConfig`
+- layout/drag zone 写回链会先读取原始 JSON，再只改目标字段，所以未知字段通常会继续保留在文件里
+
+### 1.3 语音链单独说明
+
+`voice.path` 不只影响 desktop main，也会影响 runtime tool adapter：
+
+1. `apps/runtime/tooling/adapters/voice.js`
+   - `resolveDesktopLive2dConfigPath()`
+   - `loadVoicePathMode()`
+2. 当 `voice.path = electron_native`
+   - `ttsAliyunVc()` 发布 `voice.requested`
+3. `apps/gateway/server.js`
+   - 透传 `voice.*` 事件
+4. `apps/desktop-live2d/main/desktopSuite.js`
+   - 在 gateway notification 分发中接 `voice.requested`
+   - `processVoiceRequestedEvent()` 决定 `realtime` / `non_streaming`
+5. `apps/desktop-live2d/renderer/bootstrap.js`
+   - 监听 `desktop:voice:stream-*` 或 `desktop:voice:play-*`
+
+## 2. 兼容性与格式规则
+
+- 配置文件允许 JSON 注释
+  - `apps/desktop-live2d/main/config.js`
+    - `stripJsonComments()`
+    - `parseJsonWithComments()`
+  - `apps/runtime/tooling/adapters/voice.js`
+    - `stripJsonComments()`
+    - `loadVoicePathMode()`
+- `voice` 段兼容以下旧字段别名：
+  - `voice.fallback_on_realtime_error`
+  - `voice.realtime.prebuffer_ms`
+  - `voice.realtime.idle_timeout_ms`
+- 未在当前 schema 中声明的字段：
+  - 读取阶段会被 `normalizeUiConfig()` 丢弃，不会进入 main/renderer 运行时对象
+  - 但若后续触发 layout/drag zone 写回，原始字段通常仍会保留在文件中
+
+## 3. 参数总览
+
+### 3.1 `window.*`
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `window.width` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `createMainWindow()` | 启动窗口链 | avatar 主窗口展开态默认宽度 |
+| `window.height` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `createMainWindow()` | 启动窗口链 | avatar 主窗口展开态默认高度 |
+| `window.minWidth` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `createMainWindow()`, `resolveAspectLockedWindowSize()` | 启动/resize 链 | avatar 窗口最小宽度约束 |
+| `window.minHeight` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `createMainWindow()`, `resolveAspectLockedWindowSize()` | 启动/resize 链 | avatar 窗口最小高度约束 |
+| `window.maxWidth` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `createMainWindow()`, `resolveAspectLockedWindowSize()` | 启动/resize 链 | avatar 窗口最大宽度约束 |
+| `window.maxHeight` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `createMainWindow()`, `resolveAspectLockedWindowSize()` | 启动/resize 链 | avatar 窗口最大高度约束 |
+| `window.compactWhenChatHidden` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `resolveWindowSizeForChatPanel()` | 聊天面板显隐链 | `chat panel` 隐藏时是否切到 compact 尺寸 |
+| `window.compactWidth` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `resolveWindowSizeForChatPanel()` | 聊天面板显隐链 | compact 态宽度 |
+| `window.compactHeight` | `apps/desktop-live2d/main/desktopSuite.js` | `resolveWindowMetrics()`, `resolveWindowSizeForChatPanel()` | 聊天面板显隐链 | compact 态高度 |
+| `window.placement.anchor` | `apps/desktop-live2d/main/desktopSuite.js` | `createMainWindow()`, `computeWindowBounds()` | 首次启动定位链 | 支持 `bottom-right/top-left/top-right/bottom-left/center/custom` |
+| `window.placement.marginRight` | `apps/desktop-live2d/main/desktopSuite.js` | `createMainWindow()`, `computeWindowBounds()`, `computeRightBottomWindowBounds()` | 首次启动定位链 | 右边距 |
+| `window.placement.marginBottom` | `apps/desktop-live2d/main/desktopSuite.js` | `createMainWindow()`, `computeWindowBounds()`, `computeRightBottomWindowBounds()` | 首次启动定位链 | 下边距 |
+| `window.placement.marginLeft` | `apps/desktop-live2d/main/desktopSuite.js` | `createMainWindow()`, `computeWindowBounds()` | 首次启动定位链 | 兼容支持字段，模板未显式写出 |
+| `window.placement.marginTop` | `apps/desktop-live2d/main/desktopSuite.js` | `createMainWindow()`, `computeWindowBounds()` | 首次启动定位链 | 兼容支持字段，模板未显式写出 |
+| `window.placement.x` | `apps/desktop-live2d/main/desktopSuite.js` | `createMainWindow()`, `computeWindowBounds()` | 首次启动定位链 | 仅在 `anchor = custom` 时生效 |
+| `window.placement.y` | `apps/desktop-live2d/main/desktopSuite.js` | `createMainWindow()`, `computeWindowBounds()` | 首次启动定位链 | 仅在 `anchor = custom` 时生效 |
+
+### 3.2 `render.*`
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `render.resolutionScale` | `apps/desktop-live2d/renderer/bootstrap.js` | `initPixi()` | renderer 初始化链 | 与 `window.devicePixelRatio` 相乘后再做上限裁剪 |
+| `render.maxDevicePixelRatio` | `apps/desktop-live2d/renderer/bootstrap.js` | `initPixi()` | renderer 初始化链 | renderer resolution 上限 |
+| `render.antialias` | `apps/desktop-live2d/renderer/bootstrap.js` | `initPixi()` | renderer 初始化链 | PIXI renderer 抗锯齿开关 |
+
+### 3.3 `interaction.dragZone.*`
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `interaction.dragZone.centerXRatio` | `apps/desktop-live2d/renderer/bootstrap.js` | `getCurrentDragZoneValues()`, `normalizeDragZoneValues()`, `syncWindowInteractivityFromPointer()` | 窗口穿透/拖拽链 | 定义可拖拽热区中心 X |
+| `interaction.dragZone.centerYRatio` | `apps/desktop-live2d/renderer/bootstrap.js` | `getCurrentDragZoneValues()`, `normalizeDragZoneValues()`, `syncWindowInteractivityFromPointer()` | 窗口穿透/拖拽链 | 定义可拖拽热区中心 Y |
+| `interaction.dragZone.widthRatio` | `apps/desktop-live2d/renderer/bootstrap.js` | `getCurrentDragZoneValues()`, `normalizeDragZoneValues()`, `syncWindowInteractivityFromPointer()` | 窗口穿透/拖拽链 | 热区宽度比例 |
+| `interaction.dragZone.heightRatio` | `apps/desktop-live2d/renderer/bootstrap.js` | `getCurrentDragZoneValues()`, `normalizeDragZoneValues()`, `syncWindowInteractivityFromPointer()` | 窗口穿透/拖拽链 | 热区高度比例 |
+
+说明：
+
+- 热区命中判断没有单独命名成 `isPointInsideDragZone()`；当前实现是 `syncWindowInteractivityFromPointer()` 内部的几何判断
+- `resize mode` 打开时，这条链会切回整窗可交互，不受 drag zone 限制
+
+拖拽框调参链额外经过：
+
+- `apps/desktop-live2d/renderer/bootstrap.js`
+  - `setDragZonePanelOpen()`
+  - `applyDragZoneValues()`
+  - `saveDragZoneValues()`
+- `apps/desktop-live2d/main/desktopSuite.js`
+  - `persistDragZoneOverrides()`
+- `apps/desktop-live2d/main/config.js`
+  - `upsertDesktopLive2dDragZoneOverrides()`
+
+### 3.4 `layout.*`
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `layout.targetWidthRatio` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型自动布局链 | 模型目标占宽比例 |
+| `layout.targetHeightRatio` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型自动布局链 | 模型目标占高比例 |
+| `layout.anchorXRatio` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型自动布局链 | 模型在窗口中的锚点 X |
+| `layout.anchorYRatio` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型自动布局链 | 模型在窗口中的锚点 Y |
+| `layout.offsetX` | `apps/desktop-live2d/renderer/layout.js`, `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/main/desktopSuite.js` | `computeModelLayout()`, `applyLayoutTunerValues()`, `persistLayoutOverrides()` | 模型自动布局链 / resize mode 调参链 | 主调参项之一 |
+| `layout.offsetY` | `apps/desktop-live2d/renderer/layout.js`, `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/main/desktopSuite.js` | `computeModelLayout()`, `applyLayoutTunerValues()`, `persistLayoutOverrides()` | 模型自动布局链 / resize mode 调参链 | 主调参项之一 |
+| `layout.marginX` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型可见区域约束链 | 横向安全边距 |
+| `layout.marginY` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型可见区域约束链 | 纵向安全边距 |
+| `layout.minVisibleRatioX` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()`, `clampModelPositionToViewport()` | 模型可见区域约束链 | 横向最小可见比例 |
+| `layout.minVisibleRatioY` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()`, `clampModelPositionToViewport()` | 模型可见区域约束链 | 纵向最小可见比例 |
+| `layout.pivotXRatio` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型自动布局链 | 模型 bounds 内部 pivot X |
+| `layout.pivotYRatio` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型自动布局链 | 模型 bounds 内部 pivot Y |
+| `layout.scaleMultiplier` | `apps/desktop-live2d/renderer/layout.js`, `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/main/desktopSuite.js` | `computeModelLayout()`, `applyLayoutTunerValues()`, `persistLayoutOverrides()` | 模型自动布局链 / resize mode 调参链 | 主调参项之一 |
+| `layout.minScale` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型自动布局链 | fit scale 下限 |
+| `layout.maxScale` | `apps/desktop-live2d/renderer/layout.js` | `computeModelLayout()` | 模型自动布局链 | fit scale 上限 |
+| `layout.lockScaleOnResize` | `apps/desktop-live2d/renderer/bootstrap.js` | `applyAdaptiveLayout()` | resize mode / 窗口尺寸变化链 | `false` 时窗口变化跟随重新缩放 |
+| `layout.lockPositionOnResize` | `apps/desktop-live2d/renderer/bootstrap.js` | `applyAdaptiveLayout()` | resize mode / 窗口尺寸变化链 | `true` 时普通模式优先保持已稳定位置 |
+
+layout 调参保存只会回写这三个字段：
+
+- `offsetX`
+- `offsetY`
+- `scaleMultiplier`
+
+对应函数：
+- `apps/desktop-live2d/main/config.js`
+  - `upsertDesktopLive2dLayoutOverrides()`
+
+### 3.5 `chat.panel.*`
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `chat.panel.enabled` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `resolveWindowMetrics()`, `initChatPanel()` | 聊天面板链 | 控制 chat panel 是否启用；avatar renderer 收到的是 `avatarUiConfig`，其中 `panel.enabled` 会被强制改成 `false` |
+| `chat.panel.defaultVisible` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `resolveWindowMetrics()`, `startDesktopSuite()`, `initChatPanel()` | 聊天面板链 | 控制默认显示状态 |
+| `chat.panel.width` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `createChatWindow()`, `initChatPanel()` | 聊天窗口创建链 | 决定独立 chat 窗口尺寸；avatar 页内 panel 也会套同尺寸样式 |
+| `chat.panel.height` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `createChatWindow()`, `initChatPanel()` | 聊天窗口创建链 | 决定独立 chat 窗口尺寸；avatar 页内 panel 也会套同尺寸样式 |
+| `chat.panel.maxMessages` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/renderer/chatPanelState.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `startDesktopSuite()`, `syncChatStateSummary()`, `createInitialState()` | 聊天消息保留链 | chat 历史截断上限 |
+| `chat.panel.inputEnabled` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/renderer/chat.js` | `startDesktopSuite()`, `initChatPanel()`, `applyStateSync()` | 聊天输入链 | 控制输入框、发送按钮、图片上传可用性 |
+
+### 3.6 `chat.bubble.*`
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `chat.bubble.mirrorToPanel` | `apps/desktop-live2d/renderer/bootstrap.js` | `showBubble()` | bubble 渲染链 | assistant bubble 是否镜像写入 chat panel |
+| `chat.bubble.width` | `apps/desktop-live2d/main/desktopSuite.js` | `startDesktopSuite()`, `createBubbleWindow()`, `computeBubbleWindowBounds()` | bubble 窗口创建链 | bubble 独立窗口宽度 |
+| `chat.bubble.height` | `apps/desktop-live2d/main/desktopSuite.js` | `startDesktopSuite()`, `createBubbleWindow()`, `computeBubbleWindowBounds()` | bubble 窗口创建链 | bubble 独立窗口高度 |
+| `chat.bubble.stream.lineDurationMs` | `apps/desktop-live2d/main/desktopSuite.js` | `startDesktopSuite()`, `showBubble()` | 非 streaming bubble 展示链 | 非流式输出时传给 `showBubble({ durationMs })` 的显示时长 |
+| `chat.bubble.stream.launchIntervalMs` | `apps/desktop-live2d/main/desktopSuite.js` | `startDesktopSuite()`, `ensureStreamingLaunchTimer()`, `launchNextStreamingSentence()`, `ensureStreamingDrainTimer()` | bubble streaming 链 | streaming 句子出队与尾部 drain 的基准节奏 |
+
+补充事实：
+
+- `lineDurationMs` 当前没有参与 streaming 字幕逐句生命周期；它只用于最终整段 `showBubble()` 的展示时长
+- `launchIntervalMs` 会先进入 `bubbleRuntimeConfig`，再被 streaming 定时器读取
+
+### 3.7 `actionQueue.*`
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `actionQueue.maxQueueSize` | `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/renderer/live2dActionQueuePlayer.js` | `ensureActionQueuePlayer()`, `enqueue()` | Live2D action 队列链 | 动作队列容量 |
+| `actionQueue.overflowPolicy` | `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/renderer/live2dActionQueuePlayer.js` | `ensureActionQueuePlayer()`, `enqueue()` | Live2D action 队列链 | 支持 `drop_oldest/drop_newest/reject` |
+| `actionQueue.idleFallbackEnabled` | `apps/desktop-live2d/renderer/bootstrap.js` | `ensureActionQueuePlayer()` | Live2D action idle 回退链 | `false` 时不注入 idleAction |
+| `actionQueue.idleAction.type` | `apps/desktop-live2d/main/config.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `normalizeUiConfig()`, `ensureActionQueuePlayer()` | Live2D action idle 回退链 | 支持 `motion` 或 `expression` |
+| `actionQueue.idleAction.name` | `apps/desktop-live2d/main/config.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `normalizeUiConfig()`, `ensureActionQueuePlayer()` | Live2D action idle 回退链 | idle action 名称 |
+| `actionQueue.idleAction.args.group` | `apps/desktop-live2d/main/config.js` | `normalizeUiConfig()` | Live2D action idle 回退链 | `type = motion` 时 motion group |
+| `actionQueue.idleAction.args.index` | `apps/desktop-live2d/main/config.js` | `normalizeUiConfig()` | Live2D action idle 回退链 | `type = motion` 时 motion index |
+
+### 3.8 `voice.*`
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `voice.path` | `apps/runtime/tooling/adapters/voice.js`, `apps/desktop-live2d/main/config.js` | `loadVoicePathMode()`, `normalizeUiConfig()` | runtime TTS 路由链 | `electron_native` 走 `voice.requested`；`runtime_legacy` 走 `voice.playback.electron` |
+| `voice.transport` | `apps/desktop-live2d/main/desktopSuite.js` | `processVoiceRequestedEvent()` | desktop main 语音播放链 | `realtime` 或 `non_streaming` |
+| `voice.fallbackOnRealtimeError` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/main/config.js` | `processVoiceRequestedEvent()`, `normalizeUiConfig()` | realtime TTS 容错链 | realtime 失败后是否回落到 non-streaming |
+| `voice.realtime.prebufferMs` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/renderer/realtimeVoicePlayer.js` | `processVoiceRequestedEvent()`, `startRealtimeVoicePlayback()`, `startSession()` | realtime TTS 播放链 | 首包播放前预缓冲毫秒数 |
+| `voice.realtime.idleTimeoutMs` | `apps/desktop-live2d/main/desktopSuite.js`, `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/renderer/realtimeVoicePlayer.js` | `processVoiceRequestedEvent()`, `startRealtimeVoicePlayback()`, `startSession()` | realtime TTS 播放链 | realtime chunk 超时自动结束 |
+
+### 3.9 `debug.*`
+
+这一组字段已经接线，且当前主要用于嘴形调试。
+
+| 参数 | 生效文件 | 相关函数 | 所在线路 | 说明 |
+| --- | --- | --- | --- | --- |
+| `debug.mouthTuner.visible` | `apps/desktop-live2d/main/config.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `normalizeUiConfig()`, `getMouthTunerRuntimeConfig()`, `setMouthTunerVisible()` | renderer 调试 UI 链 | 控制 `Mouth Tuner` 按钮和面板是否可见 |
+| `debug.mouthTuner.enabled` | `apps/desktop-live2d/main/config.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `normalizeUiConfig()`, `getMouthTunerRuntimeConfig()`, `setMouthTunerEnabled()` | renderer 调试 override 链 | 启动时是否默认开启嘴形 override |
+| `debug.waveformCapture.enabled` | `apps/desktop-live2d/main/config.js`, `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/main/desktopSuite.js` | `normalizeUiConfig()`, `getWaveformCaptureRuntimeConfig()`, `createMouthWaveformRecorder()` | 逐帧波形记录链 | 是否按 `request_id` 落盘完整嘴形波形 |
+| `debug.waveformCapture.captureEveryFrame` | `apps/desktop-live2d/main/config.js`, `apps/desktop-live2d/renderer/bootstrap.js` | `normalizeUiConfig()`, `getWaveformCaptureRuntimeConfig()` | renderer debug marker 链 | `true` 时每帧输出 `chain.renderer.mouth.frame_sample`，而不是只按 30 帧抽样 |
+| `debug.waveformCapture.includeApplied` | `apps/desktop-live2d/main/config.js`, `apps/desktop-live2d/renderer/bootstrap.js`, `apps/desktop-live2d/main/desktopSuite.js` | `normalizeUiConfig()`, `getWaveformCaptureRuntimeConfig()`, `createMouthWaveformRecorder()` | 最终落模回读链 | `true` 时同时记录 `chain.renderer.lipsync.frame_applied` |
+
+补充事实：
+
+- 这组字段会进入 `normalizeUiConfig()` 返回的运行时对象。
+- renderer 通过 `bridge.getRuntimeConfig()` 读取后，`Mouth Tuner` 和 waveform capture 都会真正生效。
+- waveform recorder 的默认落盘目录不由 `desktop-live2d.json` 控制，而是 main 进程环境路径：
+  - `~/yachiyo/data/desktop-live2d/mouth-waveforms`
+  - 或 `DESKTOP_LIVE2D_MOUTH_WAVEFORM_DIR`
+
+## 4. 已定义但当前未接线的字段
+
+以下字段在 `DEFAULT_UI_CONFIG` 中存在，但当前 app 主链代码扫描未发现消费点：
+
+| 参数 | 定义位置 | 现状 |
+| --- | --- | --- |
+| `chat.bubble.truncate.enabled` | `apps/desktop-live2d/shared/defaultUiConfig.js` | 未接线 |
+| `chat.bubble.truncate.maxLength` | `apps/desktop-live2d/shared/defaultUiConfig.js` | 未接线 |
+| `chat.bubble.truncate.mode` | `apps/desktop-live2d/shared/defaultUiConfig.js` | 未接线 |
+| `chat.bubble.truncate.suffix` | `apps/desktop-live2d/shared/defaultUiConfig.js` | 未接线 |
+| `chat.bubble.truncate.showHintForComplex` | `apps/desktop-live2d/shared/defaultUiConfig.js` | 未接线 |
+
+文档上应把这些字段视为“保留位”，不要当成功能已经落地。
+
+补充事实：
+
+- 仓库里有 `test/desktop-live2d/bubbleTruncate.test.js`
+- 这组测试只验证默认值和候选截断算法，并不代表 renderer/main 当前已经把 `chat.bubble.truncate.*` 接进渲染链
+
+## 5. 持久化回写链
+
+### 5.1 layout tuner
+
+1. renderer:
+   - `apps/desktop-live2d/renderer/bootstrap.js`
+   - `saveLayoutTunerValues()`
+2. main:
+   - `apps/desktop-live2d/main/desktopSuite.js`
+   - `persistLayoutOverrides()`
+3. config writer:
+   - `apps/desktop-live2d/main/config.js`
+   - `upsertDesktopLive2dLayoutOverrides()`
+
+只会写回：
+- `layout.offsetX`
+- `layout.offsetY`
+- `layout.scaleMultiplier`
+
+### 5.2 drag zone tuner
+
+1. renderer:
+   - `apps/desktop-live2d/renderer/bootstrap.js`
+   - `saveDragZoneValues()`
+2. main:
+   - `apps/desktop-live2d/main/desktopSuite.js`
+   - `persistDragZoneOverrides()`
+3. config writer:
+   - `apps/desktop-live2d/main/config.js`
+   - `upsertDesktopLive2dDragZoneOverrides()`
+
+只会写回：
+- `interaction.dragZone.centerXRatio`
+- `interaction.dragZone.centerYRatio`
+- `interaction.dragZone.widthRatio`
+- `interaction.dragZone.heightRatio`
+
+## 6. 推荐维护规则
+
+- 运行时请改 `~/yachiyo/config/desktop-live2d.json`，不要把仓库模板当成当前生效配置
+- 想调模型站位，优先改 `layout.offsetX / offsetY / scaleMultiplier`
+- 想调可拖拽热区，优先改 `interaction.dragZone.*`
+- 想调语音路由，先看 `voice.path`，再看 `voice.transport`
+- 碰到字段存在但没效果，先查本文档第 4 章，确认它是不是尚未接线

--- a/docs/modules/desktop-live2d/module-reference.md
+++ b/docs/modules/desktop-live2d/module-reference.md
@@ -117,15 +117,18 @@ DOM 更新
 
 定义位置：`apps/desktop-live2d/main/constants.js` `RPC_METHODS_V1`
 
+注：
+- 本节只描述当前 `RPC_METHODS_V1` 中仍然存在的方法。
+- 语音主链现在不是 `voice.play` / `voice.play.test` RPC，而是 `voice.requested -> desktop main -> renderer` 事件链。
+
 - `state.get`
+- `debug.mouthOverride.set`
 - `param.set` / `model.param.set`
 - `model.param.batchSet`
 - `model.motion.play`
 - `model.expression.set`
 - `chat.show` / `chat.bubble.show`
 - `chat.panel.show` / `chat.panel.hide` / `chat.panel.append` / `chat.panel.clear`
-- `voice.play`
-- `voice.play.test`
 - `tool.list` / `tool.invoke`
 
 #### 3.2.1 对外 `invoke` 协议结构
@@ -181,6 +184,8 @@ DOM 更新
 
 - `state.get`
   - `params: {}`
+- `debug.mouthOverride.set`
+  - `params: { "enabled": boolean, "mouthOpen"?: number, "mouthForm"?: number }`
 - `param.set` / `model.param.set`
   - `params: { "name": string, "value": number }`
 - `model.param.batchSet`
@@ -199,10 +204,6 @@ DOM 更新
   - `params: { "role"?: "user" | "assistant" | "system" | "tool", "text": string, "timestamp"?: integer, "requestId"?: string }`
 - `chat.panel.clear`
   - `params: {}`
-- `voice.play`
-  - `params: { "audioPath": string }`
-- `voice.play.test`
-  - `params: { "audioRef": string, "gatewayUrl"?: string }`
 - `tool.list`
   - `params: {}`
 - `tool.invoke`
@@ -274,9 +275,9 @@ Renderer 回包：
 
 当前语音播放主链已经从 RPC `invoke` 分离：
 
-`runtime voice.playback.electron -> desktopSuite runtime.event listener -> desktop:voice:play -> preload.onVoicePlay() -> renderer handleVoicePlaybackRequest()`
+`runtime voice.requested -> desktopSuite processVoiceRequestedOnDesktop() -> desktop:voice:play-memory / desktop:voice:play-remote / desktop:voice:stream-* -> renderer playback entry`
 
-兼容链仍保留 `voice.play`，但 renderer 内部最终也会走同一个播放器函数。
+兼容链仍存在 `runtime_legacy` / `voice.playback.electron` 路由，但当前主线语音路径应优先视为 `voice.requested` 事件链。
 
 ### 3.3 JSON-RPC 错误码
 

--- a/docs/process/desktop-live2d-lipsync-waveform-tuning-log.md
+++ b/docs/process/desktop-live2d-lipsync-waveform-tuning-log.md
@@ -1,0 +1,183 @@
+# Desktop Live2D Lipsync Waveform Tuning Log
+
+日期范围：2026-03-04  
+适用分支基线：`main`
+
+## 1. 目的
+
+这篇文档记录当前 `desktop-live2d` 嘴形链路的实际开发结果，而不是早期方案。
+
+重点覆盖：
+- 默认闭嘴基线统一
+- 说话态 `mouthOpen` / `mouthForm` 调参与 face mixer 的关系
+- 逐帧 waveform 采集落盘
+- 当前已知问题与下一步观察方式
+
+## 2. 当前链路
+
+### 2.1 语音到嘴形
+
+1. `apps/runtime/tooling/adapters/voice.js`
+   - `ttsAliyunVc()`
+   - 当 `voice.path = electron_native` 时发 `voice.requested`
+2. `apps/desktop-live2d/main/desktopSuite.js`
+   - `processVoiceRequestedOnDesktop()`
+   - 根据 `voice.transport` 走 `realtime` 或 `non_streaming`
+3. `apps/desktop-live2d/renderer/bootstrap.js`
+   - `playVoiceFromRemote()`
+   - `playVoiceFromBase64()`
+   - `startRealtimeVoicePlayback()`
+   - `startLipsync()`
+4. `apps/desktop-live2d/renderer/lipsyncViseme.js`
+   - `resolveVisemeFrame()`
+5. `apps/desktop-live2d/renderer/bootstrap.js`
+   - `enhanceMouthParams()`
+   - face mixer / final param write
+6. `apps/desktop-live2d/renderer/lipsyncMouthTransition.js`
+   - `stepMouthTransition()`
+
+### 2.2 当前关键分层
+
+- `lipsyncViseme.js`
+  - 从频谱与能量推断 `raw_mouth_open` / `raw_mouth_form`
+- `bootstrap.js`
+  - 做 speaking 态增益、低能量豁免、默认嘴形回落、face mixer
+- `lipsyncMouthTransition.js`
+  - 做 attack / release / neutral 过渡
+- 最终写入
+  - `ParamMouthOpenY`
+  - `ParamMouthForm`
+  - 以及少量表情相关参数
+
+## 3. 这轮落地的改动
+
+### 3.1 默认嘴形统一
+
+当前默认闭嘴嘴形被统一成同一来源，不再在多个阶段各写一套：
+- 模型加载后
+- idle fallback 后
+- 说话前预播等待
+- 说话停止后的 release 回落
+
+目标是保证“默认闭嘴”和“说话结束后的闭嘴”一致。
+
+### 3.2 face mixer
+
+当前主线已经加入最小版 face mixer，作用是把这些输入统一到最终写参数前：
+- 默认基线
+- emotion / expression 目标
+- lipsync 目标
+- debug override
+
+这样可以避免：
+- `greet` / `smile` 把 `mouthForm` 顶满
+- 说话时表情和嘴形互相抢
+
+### 3.3 lipsync 调参
+
+当前主线不是简单整包搬 `Tune` 老分支，而是只借用了调参思路：
+- 元音目标嘴形更分散
+- speaking 态 `mouthOpen` / `mouthForm` 做增益
+- 低能量帧避免过早掉成 `0/0`
+
+实际调整点主要在：
+- `apps/desktop-live2d/renderer/lipsyncViseme.js`
+- `apps/desktop-live2d/renderer/bootstrap.js`
+- `apps/desktop-live2d/renderer/lipsyncMouthTransition.js`
+
+## 4. 逐帧 waveform 采集
+
+### 4.1 为什么需要新 recorder
+
+之前只有 SSE 抽样日志，最多每 30 帧采一次，无法还原完整嘴形波形。  
+现在为每次语音请求新增了逐帧 JSONL 记录。
+
+### 4.2 记录内容
+
+renderer 持续发两类 debug marker：
+- `chain.renderer.mouth.frame_sample`
+- `chain.renderer.lipsync.frame_applied`
+
+main 进程在 `apps/desktop-live2d/main/desktopSuite.js`
+- `createMouthWaveformRecorder()`
+中订阅 renderer console debug，按 `request_id` 落盘。
+
+### 4.3 文件位置
+
+默认输出目录：
+- `~/yachiyo/data/desktop-live2d/mouth-waveforms`
+
+文件名格式：
+- `<timestamp>-<request_id>.jsonl`
+
+### 4.4 当前配置
+
+`desktop-live2d.json` 中的新字段：
+
+```json
+{
+  "debug": {
+    "waveformCapture": {
+      "enabled": true,
+      "captureEveryFrame": true,
+      "includeApplied": true
+    }
+  }
+}
+```
+
+语义：
+- `enabled`
+  - 是否启用逐帧 recorder
+- `captureEveryFrame`
+  - `true` 时 renderer 每帧输出 `mouth.frame_sample`
+- `includeApplied`
+  - `true` 时 renderer 同时输出每帧 `frame_applied`
+
+## 5. 这轮波形观察到的事实
+
+基于已落盘的逐帧文件，可以直接比较：
+- `raw_mouth_open`
+- `mouth_open`
+- `applied_mouth_open`
+- `raw_mouth_form`
+- `mouth_form`
+- `applied_mouth_form`
+
+已经确认的一个关键事实：
+- 目标值和最终应用值并不总是一致
+- 尤其 `mouthForm` 在某些帧会被别的链路顶到极值
+
+这意味着后续调优不应该只盯 `resolveVisemeFrame()` 的输出，还要看最终落模阶段。
+
+## 6. 当前文档关系
+
+### 6.1 这篇文档负责什么
+
+这篇文档只负责：
+- 开发过程
+- 调参思路
+- 真实运行观测
+- 逐帧 waveform 采集方式
+
+### 6.2 其他文档分别负责什么
+
+- `docs/VOICE_LIPSYNC_DEBUG_GUIDE.md`
+  - 当前可执行的调试步骤与 topic
+- `docs/modules/desktop-live2d/desktop-live2d-config-reference.md`
+  - `desktop-live2d.json` 字段参考
+- `docs/modules/desktop-live2d/README.md`
+  - 模块索引
+
+### 6.3 已重叠且过时的文档
+
+以下文档保留为历史调查材料，但不应再当作当前主线事实来源：
+- `docs/LIPSYNC_CONFLICT_DEBUG_GUIDE.md`
+- `docs/LIPSYNC_CONFLICT_SUMMARY.md`
+- `docs/LIPSYNC_EXPRESSION_CONFLICT_INVESTIGATION.md`
+
+它们的问题是：
+- 主要针对 2026-03-01 左右的旧 lipsync 冲突排查
+- 没有覆盖当前 face mixer
+- 没有覆盖 waveform recorder
+- 部分描述以旧实现细节为中心，不适合继续当现状文档

--- a/test/desktop-live2d/config.test.js
+++ b/test/desktop-live2d/config.test.js
@@ -8,7 +8,8 @@ const {
   resolveDesktopLive2dConfig,
   upsertDesktopLive2dLayoutOverrides,
   upsertDesktopLive2dDragZoneOverrides,
-  parseJsonWithComments
+  parseJsonWithComments,
+  syncDesktopLive2dMissingDefaults
 } = require('../../apps/desktop-live2d/main/config');
 
 test('resolveDesktopLive2dConfig applies defaults and model relative path', () => {
@@ -35,6 +36,11 @@ test('resolveDesktopLive2dConfig applies defaults and model relative path', () =
   assert.equal(config.uiConfig.actionQueue.idleAction.type, 'motion');
   assert.equal(config.uiConfig.actionQueue.idleAction.name, 'Idle');
   assert.equal(config.uiConfig.actionQueue.idleAction.args.group, 'Idle');
+  assert.equal(config.uiConfig.debug.mouthTuner.visible, false);
+  assert.equal(config.uiConfig.debug.mouthTuner.enabled, false);
+  assert.equal(config.uiConfig.debug.waveformCapture.enabled, false);
+  assert.equal(config.uiConfig.debug.waveformCapture.captureEveryFrame, true);
+  assert.equal(config.uiConfig.debug.waveformCapture.includeApplied, true);
   assert.equal(config.uiConfig.voice.path, 'electron_native');
   assert.equal(config.uiConfig.voice.transport, 'non_streaming');
   assert.equal(config.uiConfig.voice.fallbackOnRealtimeError, true);
@@ -126,6 +132,17 @@ test('resolveDesktopLive2dConfig loads overrides from YACHIYO_HOME/config/deskto
           maxMessages: 88
         }
       },
+      debug: {
+        mouthTuner: {
+          visible: true,
+          enabled: false
+        },
+        waveformCapture: {
+          enabled: true,
+          captureEveryFrame: true,
+          includeApplied: false
+        }
+      },
       actionQueue: {
         maxQueueSize: 32,
         overflowPolicy: 'drop_newest',
@@ -163,6 +180,11 @@ test('resolveDesktopLive2dConfig loads overrides from YACHIYO_HOME/config/deskto
   assert.equal(config.uiConfig.layout.lockPositionOnResize, false);
   assert.equal(config.uiConfig.chat.panel.defaultVisible, false);
   assert.equal(config.uiConfig.chat.panel.maxMessages, 88);
+  assert.equal(config.uiConfig.debug.mouthTuner.visible, true);
+  assert.equal(config.uiConfig.debug.mouthTuner.enabled, false);
+  assert.equal(config.uiConfig.debug.waveformCapture.enabled, true);
+  assert.equal(config.uiConfig.debug.waveformCapture.captureEveryFrame, true);
+  assert.equal(config.uiConfig.debug.waveformCapture.includeApplied, false);
   assert.equal(config.uiConfig.actionQueue.maxQueueSize, 32);
   assert.equal(config.uiConfig.actionQueue.overflowPolicy, 'drop_newest');
   assert.equal(config.uiConfig.actionQueue.idleFallbackEnabled, false);
@@ -293,4 +315,43 @@ test('upsertDesktopLive2dDragZoneOverrides clamps out-of-bounds drag zone inputs
     widthRatio: 0.7,
     heightRatio: 0.5
   });
+});
+
+test('syncDesktopLive2dMissingDefaults fills missing schema fields without overwriting user overrides', () => {
+  const configPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'live2d-sync-defaults-')), 'desktop-live2d.json');
+  fs.writeFileSync(configPath, `{
+  "window": {
+    "width": 512
+  },
+  "interaction": {
+    "dragZone": {
+      "widthRatio": 0.42
+    }
+  },
+  "voice": {
+    "transport": "realtime"
+  }
+}
+`, 'utf8');
+
+  const { nextRaw, addedPaths } = syncDesktopLive2dMissingDefaults(configPath);
+  const saved = parseJsonWithComments(fs.readFileSync(configPath, 'utf8'));
+
+  assert.equal(nextRaw.window.width, 512);
+  assert.equal(nextRaw.interaction.dragZone.widthRatio, 0.42);
+  assert.equal(nextRaw.voice.transport, 'realtime');
+  assert.equal(saved.window.width, 512);
+  assert.equal(saved.interaction.dragZone.widthRatio, 0.42);
+  assert.equal(saved.voice.transport, 'realtime');
+  assert.equal(saved.window.height, 500);
+  assert.equal(saved.interaction.dragZone.centerXRatio, 0.5);
+  assert.equal(saved.debug.mouthTuner.visible, false);
+  assert.equal(saved.debug.waveformCapture.enabled, false);
+  assert.equal(saved.debug.waveformCapture.captureEveryFrame, true);
+  assert.equal(saved.debug.waveformCapture.includeApplied, true);
+  assert.equal(saved.voice.path, 'electron_native');
+  assert.ok(addedPaths.includes('window.height'));
+  assert.ok(addedPaths.includes('debug'));
+  assert.ok(!addedPaths.includes('window.width'));
+  assert.ok(!addedPaths.includes('voice.transport'));
 });

--- a/test/desktop-live2d/lipsyncViseme.test.js
+++ b/test/desktop-live2d/lipsyncViseme.test.js
@@ -120,6 +120,43 @@ test('resolveVisemeFrame falls back when speech energy is absent', () => {
   assert.equal(frame.mouthForm, 0);
 });
 
+test('resolveVisemeFrame holds the previous speaking mouth shape across brief low-signal gaps', () => {
+  const bright = makeSpectrum({
+    low: 0.08,
+    lowMid: 0.12,
+    mid: 0.3,
+    highMid: 0.92,
+    high: 0.76
+  });
+  const silent = makeSpectrum();
+  const runtimeState = createRuntimeState();
+
+  const activeFrame = resolveVisemeFrame({
+    frequencyBuffer: bright.buffer,
+    sampleRate: bright.sampleRate,
+    voiceEnergy: 0.8,
+    speaking: true,
+    fallbackOpen: 0,
+    fallbackForm: 0,
+    state: runtimeState
+  });
+
+  const heldFrame = resolveVisemeFrame({
+    frequencyBuffer: silent.buffer,
+    sampleRate: silent.sampleRate,
+    voiceEnergy: 0.01,
+    speaking: true,
+    fallbackOpen: 0,
+    fallbackForm: 0,
+    state: runtimeState
+  });
+
+  assert.ok(activeFrame.mouthOpen > 0.25);
+  assert.ok(heldFrame.mouthOpen > 0.05);
+  assert.ok(Math.abs(heldFrame.mouthForm) > 0.05);
+  assert.ok(heldFrame.mouthOpen < activeFrame.mouthOpen);
+});
+
 test('deriveMouthParams gives distinct vowel mouth shapes', () => {
   const aShape = deriveMouthParams({ a: 1, i: 0, u: 0, e: 0, o: 0 }, { voiceEnergy: 0.7, opennessHint: 0.8, spectralBalance: 0 });
   const iShape = deriveMouthParams({ a: 0, i: 1, u: 0, e: 0, o: 0 }, { voiceEnergy: 0.4, opennessHint: 0.35, spectralBalance: 0.6 });

--- a/test/desktop-live2d/rpcValidator.test.js
+++ b/test/desktop-live2d/rpcValidator.test.js
@@ -47,6 +47,22 @@ test('validateRpcRequest accepts tool.invoke payload', () => {
   assert.equal(result.request.method, 'tool.invoke');
 });
 
+test('validateRpcRequest accepts debug.mouthOverride.set payload', () => {
+  const result = validateRpcRequest({
+    jsonrpc: '2.0',
+    id: 'mouth-1',
+    method: 'debug.mouthOverride.set',
+    params: {
+      enabled: true,
+      mouthOpen: 0.48,
+      mouthForm: -0.32
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.request.method, 'debug.mouthOverride.set');
+});
+
 test('validateRpcRequest rejects non-whitelisted method', () => {
   const result = validateRpcRequest({
     jsonrpc: '2.0',


### PR DESCRIPTION
## Summary
- make desktop Live2D lipsync look more natural by refining viseme shaping, mouth transition smoothing, and speaking-time mouth enhancement
- add mouth tuner and waveform capture support so target vs applied mouth params can be inspected frame-by-frame
- update desktop-live2d docs to reflect the current lipsync chain, debug workflow, and config surface

## Testing
- node --test test/desktop-live2d/config.test.js test/desktop-live2d/lipsyncViseme.test.js test/desktop-live2d/lipsyncMouthTransition.test.js test/desktop-live2d/live2dActionQueuePlayer.test.js test/desktop-live2d/live2dActionExecutor.test.js test/desktop-live2d/rpcValidator.test.js
